### PR TITLE
FEATURE: add full Jira integration with bi-directional sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,14 @@ graph LR
 
 ## Features
 
-- **Feedback Ingestion** — Import from CSV, JSON, manual entry, or webhooks
+- **Feedback Ingestion** — Import from CSV, JSON, Jira, manual entry, or webhooks
 - **AI Theme Discovery** — Automatically clusters similar feedback into themes using embeddings
 - **Smart Proposals** — AI-generated feature proposals with RICE prioritization
 - **Evidence Linking** — Every proposal is backed by real customer feedback
 - **Spec Generation** — Generate PRDs and agent-ready prompts from approved proposals
+- **Jira Integration** — Bi-directional sync: export proposals/epics to Jira, import Jira issues as feedback, real-time webhook sync
 - **Dashboard** — Overview of feedback volume, sentiment trends, and top themes
-- **Settings** — AI config, synthesis tuning, data management, API key management
+- **Settings** — AI config, synthesis tuning, Jira configuration, data management, API key management
 
 ## Quick Start
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -390,3 +390,182 @@ List API keys (prefix only).
 ### DELETE /api/settings/api-keys/:id
 
 Revoke an API key.
+
+---
+
+## Jira Integration
+
+### PUT /api/jira/config
+
+Save Jira configuration settings.
+
+**Request Body:**
+
+| Field              | Type   | Required | Description                        |
+| ------------------ | ------ | -------- | ---------------------------------- |
+| `jira_host`        | string | No       | Jira instance URL (must be HTTPS)  |
+| `jira_email`       | string | No       | Jira account email                 |
+| `jira_api_token`   | string | No       | Jira API token                     |
+| `jira_project_key` | string | No       | Default project key (max 20 chars) |
+| `jira_issue_type`  | string | No       | Default issue type (max 50 chars)  |
+
+**Response 200:**
+
+```json
+{ "data": { "saved": true } }
+```
+
+### POST /api/jira/test
+
+Test the Jira connection with current credentials.
+
+**Response 200:**
+
+```json
+{
+  "data": {
+    "success": true,
+    "message": "Connected to My Jira",
+    "serverTitle": "My Jira"
+  }
+}
+```
+
+### GET /api/jira/projects
+
+List available Jira projects for the connected account.
+
+**Response 200:**
+
+```json
+{ "data": [{ "id": "10000", "key": "PROJ", "name": "My Project" }] }
+```
+
+### GET /api/jira/issue-types
+
+List issue types for the configured project (excludes subtasks).
+
+**Response 200:**
+
+```json
+{ "data": [{ "id": "10001", "name": "Story", "subtask": false }] }
+```
+
+### POST /api/jira/export/:proposalId
+
+Export a proposal to Jira as a new issue. The description is formatted in ADF with problem, solution, RICE scores, and customer evidence.
+
+**Response 201:**
+
+```json
+{
+  "data": {
+    "id": "uuid",
+    "jiraKey": "PROJ-42",
+    "jiraUrl": "https://your-jira.atlassian.net/browse/PROJ-42"
+  }
+}
+```
+
+### POST /api/jira/sync/:proposalId
+
+Sync the Jira issue status back to the local record.
+
+**Response 200:**
+
+```json
+{ "data": { "jiraKey": "PROJ-42", "status": "In Progress" } }
+```
+
+### GET /api/jira/issues
+
+List all exported Jira issues with linked proposal data.
+
+### GET /api/jira/issues/:proposalId
+
+Get the Jira issue linked to a specific proposal. Returns `null` if no link exists.
+
+### DELETE /api/jira/issues/:proposalId
+
+Unlink a Jira issue from a proposal (does not delete the Jira issue). Returns `204`.
+
+### POST /api/jira/export-theme/:themeId
+
+Export a theme as a Jira Epic with all its proposals as child Stories.
+
+**Response 201:**
+
+```json
+{
+  "data": {
+    "epicKey": "PROJ-100",
+    "epicUrl": "https://your-jira.atlassian.net/browse/PROJ-100",
+    "storiesCreated": 3,
+    "storiesSkipped": 1
+  }
+}
+```
+
+### POST /api/jira/attach-spec/:proposalId
+
+Attach the generated PRD spec as a formatted comment on the linked Jira issue.
+
+**Response 200:**
+
+```json
+{ "data": { "jiraKey": "PROJ-42", "commented": true } }
+```
+
+### POST /api/jira/import-feedback
+
+Import Jira issues as ShipScope feedback items.
+
+**Request Body:**
+
+| Field        | Type   | Required | Description                                      |
+| ------------ | ------ | -------- | ------------------------------------------------ |
+| `jql`        | string | No       | Custom JQL query (default: project bugs/stories) |
+| `maxResults` | number | No       | Max items to import (capped at 100)              |
+
+**Response 201:**
+
+```json
+{ "data": { "imported": 12, "skipped": 3, "sourceId": "uuid" } }
+```
+
+### POST /api/jira/sync-all
+
+Sync status for all linked Jira issues. Automatically marks proposals as "shipped" when the Jira issue status reaches Done/Closed/Resolved.
+
+**Response 200:**
+
+```json
+{ "data": { "synced": 10, "autoShipped": 2, "errors": 0 } }
+```
+
+### POST /api/jira/webhook
+
+Receive Jira webhook events for real-time status sync. Configure in Jira under Settings > System > Webhooks.
+
+**Response 200:**
+
+```json
+{ "data": { "processed": true, "jiraKey": "PROJ-42" } }
+```
+
+### GET /api/jira/dashboard
+
+Get Jira integration summary for the dashboard widget.
+
+**Response 200:**
+
+```json
+{
+  "data": {
+    "totalExported": 15,
+    "byStatus": { "To Do": 5, "In Progress": 8, "Done": 2 },
+    "recentExports": [],
+    "epicCount": 3
+  }
+}
+```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -42,11 +42,17 @@ graph TB
         REDIS[(Redis 7<br/>Queue + Cache)]
     end
 
+    subgraph "External Integrations"
+        JIRA[Jira Cloud<br/>REST API v3]
+    end
+
     WEB -->|REST API| EXPRESS
     EXPRESS --> SERVICES
     SERVICES --> PG
     SERVICES --> REDIS
     SERVICES -->|Enqueue jobs| REDIS
+    SERVICES -->|Export / Import / Sync| JIRA
+    JIRA -->|Webhooks| EXPRESS
     WORKERS -->|Process jobs| REDIS
     WORKERS --> OPENAI
     WORKERS --> PG
@@ -112,6 +118,7 @@ graph TD
 | `packages/core`  | TypeScript types, Zod schemas, shared constants | Business logic, I/O, database access         |
 | Express Routes   | HTTP parsing, validation, response formatting   | Business logic, direct DB queries            |
 | Service Layer    | Business logic, orchestration, caching          | HTTP concerns, direct Prisma calls in routes |
+| Jira Service     | Jira API integration, export/import/sync        | UI rendering, HTTP concerns                  |
 | Prisma ORM       | Database queries, migrations, type-safe access  | Business logic, HTTP concerns                |
 | BullMQ Workers   | Background job processing, AI pipeline          | Serving HTTP requests                        |
 | React Components | UI rendering, user interaction                  | Direct API calls (uses TanStack Query)       |
@@ -133,7 +140,7 @@ erDiagram
     }
 ```
 
-Key tables: FeedbackItem, Theme, Proposal, Spec, ApiKey, Setting, ActivityLog
+Key tables: FeedbackItem, Theme, Proposal, Spec, JiraIssue, ApiKey, Setting, ActivityLog
 
 ## Security Layers
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -87,6 +87,33 @@ docker compose -f docker-compose.prod.yml exec api \
 | `WEB_PORT`            | No       | `3000`                  | Host port for the web UI                  |
 | `LOG_LEVEL`           | No       | `info`                  | Log level: debug, info, warn, error       |
 
+## Jira Integration (Optional)
+
+Jira is configured through the Settings UI after deployment — no environment variables needed.
+
+### Setup
+
+1. Go to **Settings → Jira Integration** in the ShipScope UI
+2. Enter your Jira Cloud host URL (e.g. `https://yourcompany.atlassian.net`)
+3. Enter your Jira account email and [API token](https://id.atlassian.com/manage-profile/security/api-tokens)
+4. Click **Test Connection** to verify credentials
+5. Select your default project and issue type from the dropdowns
+6. Click **Save**
+
+### Real-Time Sync via Webhooks
+
+To receive instant status updates when Jira issues change:
+
+1. In Jira, go to **Settings → System → Webhooks**
+2. Create a new webhook pointing to:
+   ```
+   https://your-domain.com/api/jira/webhook
+   ```
+3. Select the **Issue updated** event
+4. Save the webhook
+
+When a Jira issue reaches Done/Closed/Resolved, ShipScope will automatically mark the linked proposal as "shipped".
+
 ## Updating
 
 ```bash

--- a/packages/api/prisma/migrations/20260314000000_add_jira_integration/migration.sql
+++ b/packages/api/prisma/migrations/20260314000000_add_jira_integration/migration.sql
@@ -1,0 +1,36 @@
+-- CreateTable
+CREATE TABLE "jira_issues" (
+    "id" TEXT NOT NULL,
+    "proposalId" TEXT NOT NULL,
+    "jiraKey" TEXT NOT NULL,
+    "jiraId" TEXT NOT NULL,
+    "jiraUrl" TEXT NOT NULL,
+    "issueType" TEXT NOT NULL DEFAULT 'Story',
+    "status" TEXT NOT NULL DEFAULT 'To Do',
+    "summary" TEXT NOT NULL,
+    "epicKey" TEXT,
+    "syncedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "jira_issues_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "jira_issues_proposalId_key" ON "jira_issues"("proposalId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "jira_issues_jiraKey_key" ON "jira_issues"("jiraKey");
+
+-- CreateIndex
+CREATE INDEX "jira_issues_proposalId_idx" ON "jira_issues"("proposalId");
+
+-- CreateIndex
+CREATE INDEX "jira_issues_epicKey_idx" ON "jira_issues"("epicKey");
+
+-- AlterTable - Add Jira Epic fields to Theme
+ALTER TABLE "Theme" ADD COLUMN "jiraEpicKey" TEXT;
+ALTER TABLE "Theme" ADD COLUMN "jiraEpicUrl" TEXT;
+
+-- AddForeignKey
+ALTER TABLE "jira_issues" ADD CONSTRAINT "jira_issues_proposalId_fkey" FOREIGN KEY ("proposalId") REFERENCES "Proposal"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/api/prisma/schema.prisma
+++ b/packages/api/prisma/schema.prisma
@@ -78,6 +78,10 @@ model Theme {
   avgUrgency       Float  @default(0)
   opportunityScore Float  @default(0)
 
+  // Jira Integration
+  jiraEpicKey  String?  // e.g. "PROJ-100" — linked Jira Epic
+  jiraEpicUrl  String?  // Full URL to the Jira Epic
+
   // Relations
   feedbackItems FeedbackThemeLink[]
   proposals     Proposal[]
@@ -125,6 +129,7 @@ model Proposal {
   theme       Theme?  @relation(fields: [themeId], references: [id])
   evidence    ProposalEvidence[]
   specs       Spec[]
+  jiraIssue   JiraIssue?
 
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
@@ -204,4 +209,33 @@ model Setting {
   updatedAt DateTime @updatedAt
 
   @@map("settings")
+}
+
+// ============================================
+// JIRA INTEGRATION
+// ============================================
+
+model JiraIssue {
+  id          String   @id @default(cuid())
+  proposalId  String
+  proposal    Proposal @relation(fields: [proposalId], references: [id])
+
+  // Jira issue data
+  jiraKey     String   // e.g. "PROJ-123"
+  jiraId      String   // Jira internal ID
+  jiraUrl     String   // Full URL to the issue
+  issueType   String   @default("Story") // Story, Task, Bug, Epic
+  status      String   @default("To Do") // Jira workflow status
+  summary     String
+  epicKey     String?  // Parent epic key if created via theme export
+  syncedAt    DateTime @default(now())
+
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  @@unique([proposalId])
+  @@unique([jiraKey])
+  @@index([proposalId])
+  @@index([epicKey])
+  @@map("jira_issues")
 }

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -19,6 +19,7 @@ import specRoutes from './routes/specs';
 import webhookRoutes from './routes/webhook';
 import settingsRoutes from './routes/settings';
 import dashboardRoutes from './routes/dashboard';
+import jiraRoutes from './routes/jira';
 
 export function createApp() {
   const app = express();
@@ -62,6 +63,7 @@ export function createApp() {
   app.use('/api/specs', demoGuard, specRoutes);
   app.use('/api/feedback/webhook', demoGuard, webhookRoutes);
   app.use('/api/settings', demoGuard, settingsRoutes);
+  app.use('/api/jira', demoGuard, jiraRoutes);
   app.use('/api/dashboard', dashboardRoutes);
 
   // Error handler (must be last)

--- a/packages/api/src/routes/jira.ts
+++ b/packages/api/src/routes/jira.ts
@@ -1,0 +1,289 @@
+import { Router, type Request, type Response, type NextFunction } from 'express';
+import { jiraService } from '../services/jira.service';
+import { settingsService } from '../services/settings.service';
+import { activityService } from '../services/activity.service';
+import { validate } from '../middleware/validate';
+import { jiraConfigSchema } from '../schemas/jira.schema';
+import { AppError } from '../lib/errors';
+
+const router = Router();
+
+// ─── Configuration ────────────────────────────────────────
+
+/**
+ * PUT /api/jira/config
+ * Save Jira configuration (host, email, API token, project, issue type).
+ */
+router.put(
+  '/config',
+  validate(jiraConfigSchema, 'body'),
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const settings = req.body as Record<string, string>;
+      await settingsService.bulkSet(settings);
+      res.json({ data: { saved: true } });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+/**
+ * POST /api/jira/test
+ * Test the Jira connection with current credentials.
+ */
+router.post('/test', async (_req: Request, res: Response, next: NextFunction) => {
+  try {
+    const result = await jiraService.testConnection();
+    res.json({ data: result });
+  } catch (err) {
+    next(err);
+  }
+});
+
+/**
+ * GET /api/jira/projects
+ * List available Jira projects.
+ */
+router.get('/projects', async (_req: Request, res: Response, next: NextFunction) => {
+  try {
+    const projects = await jiraService.listProjects();
+    res.json({ data: projects });
+  } catch (err) {
+    next(err);
+  }
+});
+
+/**
+ * GET /api/jira/issue-types
+ * List issue types for the configured Jira project.
+ */
+router.get('/issue-types', async (_req: Request, res: Response, next: NextFunction) => {
+  try {
+    const types = await jiraService.listIssueTypes();
+    res.json({ data: types });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// ─── Export & Sync ────────────────────────────────────────
+
+/**
+ * POST /api/jira/export/:proposalId
+ * Export a proposal to Jira as a new issue.
+ */
+router.post('/export/:proposalId', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const result = await jiraService.exportProposal(req.params.proposalId);
+
+    await activityService.log({
+      type: 'jira_export',
+      description: `Exported proposal to Jira as ${result.jiraKey}`,
+      metadata: { proposalId: req.params.proposalId, jiraKey: result.jiraKey },
+    });
+
+    res.status(201).json({ data: result });
+  } catch (err) {
+    if (err instanceof AppError) {
+      res.status(err.statusCode).json({ error: err.message, code: err.code });
+      return;
+    }
+    next(err);
+  }
+});
+
+/**
+ * POST /api/jira/sync/:proposalId
+ * Sync the Jira issue status back to the local record.
+ */
+router.post('/sync/:proposalId', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const result = await jiraService.syncStatus(req.params.proposalId);
+    res.json({ data: result });
+  } catch (err) {
+    if (err instanceof AppError) {
+      res.status(err.statusCode).json({ error: err.message, code: err.code });
+      return;
+    }
+    next(err);
+  }
+});
+
+/**
+ * GET /api/jira/issues
+ * List all exported Jira issues.
+ */
+router.get('/issues', async (_req: Request, res: Response, next: NextFunction) => {
+  try {
+    const issues = await jiraService.listExported();
+    res.json({ data: issues });
+  } catch (err) {
+    next(err);
+  }
+});
+
+/**
+ * GET /api/jira/issues/:proposalId
+ * Get the Jira issue linked to a specific proposal.
+ */
+router.get('/issues/:proposalId', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const issue = await jiraService.getByProposal(req.params.proposalId);
+    res.json({ data: issue });
+  } catch (err) {
+    next(err);
+  }
+});
+
+/**
+ * DELETE /api/jira/issues/:proposalId
+ * Unlink a Jira issue from a proposal (does not delete the Jira issue itself).
+ */
+router.delete('/issues/:proposalId', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    await jiraService.unlink(req.params.proposalId);
+    res.status(204).send();
+  } catch (err) {
+    if (err instanceof AppError) {
+      res.status(err.statusCode).json({ error: err.message, code: err.code });
+      return;
+    }
+    next(err);
+  }
+});
+
+// ─── Theme → Epic Bulk Export ─────────────────────────────
+
+/**
+ * POST /api/jira/export-theme/:themeId
+ * Export a theme as a Jira Epic with all its proposals as child Stories.
+ */
+router.post('/export-theme/:themeId', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const result = await jiraService.exportThemeAsEpic(req.params.themeId);
+
+    await activityService.log({
+      type: 'jira_export',
+      description: `Exported theme as Epic ${result.epicKey} with ${result.storiesCreated} stories`,
+      metadata: {
+        themeId: req.params.themeId,
+        epicKey: result.epicKey,
+        storiesCreated: result.storiesCreated,
+        storiesSkipped: result.storiesSkipped,
+      },
+    });
+
+    res.status(201).json({ data: result });
+  } catch (err) {
+    if (err instanceof AppError) {
+      res.status(err.statusCode).json({ error: err.message, code: err.code });
+      return;
+    }
+    next(err);
+  }
+});
+
+// ─── Spec Attachment ──────────────────────────────────────
+
+/**
+ * POST /api/jira/attach-spec/:proposalId
+ * Attach the generated PRD spec as a comment on the linked Jira issue.
+ */
+router.post('/attach-spec/:proposalId', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const result = await jiraService.attachSpec(req.params.proposalId);
+    res.json({ data: result });
+  } catch (err) {
+    if (err instanceof AppError) {
+      res.status(err.statusCode).json({ error: err.message, code: err.code });
+      return;
+    }
+    next(err);
+  }
+});
+
+// ─── Feedback Import from Jira ────────────────────────────
+
+/**
+ * POST /api/jira/import-feedback
+ * Import issues from configured Jira project as feedback items.
+ */
+router.post('/import-feedback', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { jql, maxResults } = req.body as { jql?: string; maxResults?: number };
+    const result = await jiraService.importFeedbackFromJira({ jql, maxResults });
+
+    await activityService.log({
+      type: 'import',
+      description: `Imported ${result.imported} items from Jira (${result.skipped} skipped)`,
+      metadata: { source: 'jira', imported: result.imported, skipped: result.skipped },
+    });
+
+    res.status(201).json({ data: result });
+  } catch (err) {
+    if (err instanceof AppError) {
+      res.status(err.statusCode).json({ error: err.message, code: err.code });
+      return;
+    }
+    next(err);
+  }
+});
+
+// ─── Bulk Sync ────────────────────────────────────────────
+
+/**
+ * POST /api/jira/sync-all
+ * Sync status for all linked Jira issues. Auto-ships proposals
+ * when Jira issue status reaches "Done".
+ */
+router.post('/sync-all', async (_req: Request, res: Response, next: NextFunction) => {
+  try {
+    const result = await jiraService.syncAllStatuses();
+
+    if (result.autoShipped > 0) {
+      await activityService.log({
+        type: 'jira_export',
+        description: `Jira sync: ${result.synced} synced, ${result.autoShipped} auto-shipped`,
+        metadata: result,
+      });
+    }
+
+    res.json({ data: result });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// ─── Jira Webhook Receiver ───────────────────────────────
+
+/**
+ * POST /api/jira/webhook
+ * Receive Jira webhook events for real-time status sync.
+ * Configure in Jira: Settings → System → Webhooks
+ */
+router.post('/webhook', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const result = await jiraService.handleWebhook(req.body);
+    res.json({ data: result });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// ─── Dashboard Summary ───────────────────────────────────
+
+/**
+ * GET /api/jira/dashboard
+ * Get Jira integration summary for the dashboard widget.
+ */
+router.get('/dashboard', async (_req: Request, res: Response, next: NextFunction) => {
+  try {
+    const summary = await jiraService.getDashboardSummary();
+    res.json({ data: summary });
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/packages/api/src/routes/proposals.ts
+++ b/packages/api/src/routes/proposals.ts
@@ -22,31 +22,39 @@ const router = Router();
 router.post(
   '/generate',
   validate(generateProposalsSchema, 'body'),
-  async (req: Request, res: Response) => {
-    const { topN } = req.body;
-    const result = await generateFromThemes(topN);
+  async (req: Request, res: Response, next) => {
+    try {
+      const { topN } = req.body;
+      const result = await generateFromThemes(topN);
 
-    // Link evidence for newly created proposals
-    const proposals = await listProposals({ status: 'proposed', pageSize: 100 });
-    for (const proposal of proposals.data) {
-      try {
-        await linkEvidence(proposal.id);
-      } catch {
-        // Non-fatal: evidence linking failure shouldn't fail the response
+      // Link evidence for newly created proposals
+      const proposals = await listProposals({ status: 'proposed', pageSize: 100 });
+      for (const proposal of proposals.data) {
+        try {
+          await linkEvidence(proposal.id);
+        } catch {
+          // Non-fatal: evidence linking failure shouldn't fail the response
+        }
       }
+
+      await activityService.log({
+        type: 'proposal_generation',
+        description: `Generated ${result.proposalsCreated} proposals (${result.proposalsSkipped} skipped)`,
+        metadata: {
+          created: result.proposalsCreated,
+          skipped: result.proposalsSkipped,
+          errors: result.errors.length,
+        },
+      });
+
+      res.status(201).json({ data: result });
+    } catch (err) {
+      if (err instanceof AppError) {
+        res.status(err.statusCode).json({ error: err.message, code: err.code });
+        return;
+      }
+      next(err);
     }
-
-    await activityService.log({
-      type: 'proposal_generation',
-      description: `Generated ${result.proposalsCreated} proposals (${result.proposalsSkipped} skipped)`,
-      metadata: {
-        created: result.proposalsCreated,
-        skipped: result.proposalsSkipped,
-        errors: result.errors.length,
-      },
-    });
-
-    res.status(201).json({ data: result });
   },
 );
 

--- a/packages/api/src/schemas/jira.schema.ts
+++ b/packages/api/src/schemas/jira.schema.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+
+export const exportToJiraSchema = z.object({
+  proposalId: z.string().min(1, 'Proposal ID is required'),
+});
+
+export const jiraConfigSchema = z.object({
+  jira_host: z
+    .string()
+    .url('Must be a valid URL')
+    .refine((url) => url.startsWith('https://'), 'Jira host must use HTTPS')
+    .optional(),
+  jira_email: z.string().email('Must be a valid email').optional(),
+  jira_api_token: z.string().min(1).optional(),
+  jira_project_key: z.string().min(1).max(20).optional(),
+  jira_issue_type: z.string().min(1).max(50).optional(),
+});

--- a/packages/api/src/services/activity.service.ts
+++ b/packages/api/src/services/activity.service.ts
@@ -1,7 +1,12 @@
-import { type Prisma } from '@prisma/client';
+import type { Prisma } from '@prisma/client';
 import { prisma } from '../lib/prisma';
 
-export type ActivityType = 'import' | 'synthesis' | 'proposal_generation' | 'spec_generation';
+export type ActivityType =
+  | 'import'
+  | 'synthesis'
+  | 'proposal_generation'
+  | 'spec_generation'
+  | 'jira_export';
 
 interface LogActivityInput {
   type: ActivityType;

--- a/packages/api/src/services/jira.service.ts
+++ b/packages/api/src/services/jira.service.ts
@@ -1,0 +1,942 @@
+import { prisma } from '../lib/prisma';
+import { NotFound, BadRequest } from '../lib/errors';
+import { logger } from '../lib/logger';
+import { settingsService } from './settings.service';
+
+// ─── Setting Keys ─────────────────────────────────────────
+
+export const JIRA_SETTING_KEYS = {
+  JIRA_HOST: 'jira_host',
+  JIRA_EMAIL: 'jira_email',
+  JIRA_API_TOKEN: 'jira_api_token',
+  JIRA_PROJECT_KEY: 'jira_project_key',
+  JIRA_ISSUE_TYPE: 'jira_issue_type',
+} as const;
+
+// ─── Types ────────────────────────────────────────────────
+
+interface JiraConfig {
+  host: string;
+  email: string;
+  apiToken: string;
+  projectKey: string;
+  issueType: string;
+}
+
+interface JiraProject {
+  id: string;
+  key: string;
+  name: string;
+}
+
+interface JiraIssueType {
+  id: string;
+  name: string;
+  subtask: boolean;
+}
+
+interface JiraCreateResponse {
+  id: string;
+  key: string;
+  self: string;
+}
+
+interface JiraIssueResponse {
+  id: string;
+  key: string;
+  fields: {
+    summary: string;
+    status: { name: string };
+    issuetype: { name: string };
+  };
+}
+
+// ─── Helpers ──────────────────────────────────────────────
+
+async function getJiraConfig(): Promise<JiraConfig> {
+  const [host, email, apiToken, projectKey, issueType] = await Promise.all([
+    settingsService.getRaw(JIRA_SETTING_KEYS.JIRA_HOST),
+    settingsService.getRaw(JIRA_SETTING_KEYS.JIRA_EMAIL),
+    settingsService.getRaw(JIRA_SETTING_KEYS.JIRA_API_TOKEN),
+    settingsService.getRaw(JIRA_SETTING_KEYS.JIRA_PROJECT_KEY),
+    settingsService.getRaw(JIRA_SETTING_KEYS.JIRA_ISSUE_TYPE),
+  ]);
+
+  if (!host || !email || !apiToken) {
+    throw BadRequest('Jira is not configured. Please set host, email, and API token in settings.');
+  }
+
+  return {
+    host: host.replace(/\/+$/, ''), // strip trailing slashes
+    email,
+    apiToken,
+    projectKey: projectKey || '',
+    issueType: issueType || 'Story',
+  };
+}
+
+function jiraHeaders(config: JiraConfig): Record<string, string> {
+  const auth = Buffer.from(`${config.email}:${config.apiToken}`).toString('base64');
+  return {
+    Authorization: `Basic ${auth}`,
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+  };
+}
+
+async function jiraFetch<T>(
+  config: JiraConfig,
+  path: string,
+  options: RequestInit = {},
+): Promise<T> {
+  const url = `${config.host}/rest/api/3${path}`;
+  const response = await fetch(url, {
+    ...options,
+    headers: { ...jiraHeaders(config), ...(options.headers as Record<string, string>) },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    logger.error(`Jira API error [${response.status}]: ${body}`);
+    throw BadRequest(`Jira API error (${response.status}): ${body}`);
+  }
+
+  return response.json() as Promise<T>;
+}
+
+// ─── Service ──────────────────────────────────────────────
+
+export const jiraService = {
+  /**
+   * Test the Jira connection with current credentials.
+   */
+  async testConnection(): Promise<{ success: boolean; message: string; serverTitle?: string }> {
+    try {
+      const config = await getJiraConfig();
+      const data = await jiraFetch<{ serverTitle?: string; baseUrl?: string }>(
+        config,
+        '/serverInfo',
+      );
+      return {
+        success: true,
+        message: `Connected to ${data.serverTitle || config.host}`,
+        serverTitle: data.serverTitle,
+      };
+    } catch (err) {
+      return {
+        success: false,
+        message: err instanceof Error ? err.message : 'Unknown error connecting to Jira',
+      };
+    }
+  },
+
+  /**
+   * List available projects that the configured user has access to.
+   */
+  async listProjects(): Promise<JiraProject[]> {
+    const config = await getJiraConfig();
+    const data = await jiraFetch<JiraProject[]>(config, '/project');
+    return data.map((p) => ({ id: p.id, key: p.key, name: p.name }));
+  },
+
+  /**
+   * List issue types for the configured project.
+   */
+  async listIssueTypes(): Promise<JiraIssueType[]> {
+    const config = await getJiraConfig();
+    if (!config.projectKey) {
+      throw BadRequest('No Jira project key configured');
+    }
+    const data = await jiraFetch<{ issueTypes: JiraIssueType[] }>(
+      config,
+      `/project/${encodeURIComponent(config.projectKey)}`,
+    );
+    return (data.issueTypes || [])
+      .filter((t) => !t.subtask)
+      .map((t) => ({ id: t.id, name: t.name, subtask: t.subtask }));
+  },
+
+  /**
+   * Export a proposal to Jira as a new issue.
+   */
+  async exportProposal(proposalId: string): Promise<{
+    id: string;
+    jiraKey: string;
+    jiraUrl: string;
+  }> {
+    const config = await getJiraConfig();
+
+    if (!config.projectKey) {
+      throw BadRequest('No Jira project key configured');
+    }
+
+    // Check if already exported
+    const existing = await prisma.jiraIssue.findUnique({ where: { proposalId } });
+    if (existing) {
+      throw BadRequest(`Proposal already exported to Jira as ${existing.jiraKey}`);
+    }
+
+    // Get proposal with evidence
+    const proposal = await prisma.proposal.findUnique({
+      where: { id: proposalId },
+      include: {
+        theme: { select: { name: true } },
+        evidence: {
+          take: 10,
+          orderBy: { relevanceScore: 'desc' },
+          include: {
+            feedbackItem: { select: { content: true, author: true, channel: true } },
+          },
+        },
+      },
+    });
+
+    if (!proposal) throw NotFound('Proposal');
+
+    // Build description in Atlassian Document Format (ADF)
+    const descriptionAdf = buildJiraDescription(proposal);
+
+    const issueData = {
+      fields: {
+        project: { key: config.projectKey },
+        summary: proposal.title,
+        description: descriptionAdf,
+        issuetype: { name: config.issueType },
+        labels: [
+          'shipscope',
+          proposal.theme?.name ? `theme-${slugify(proposal.theme.name)}` : '',
+        ].filter(Boolean),
+      },
+    };
+
+    const result = await jiraFetch<JiraCreateResponse>(config, '/issue', {
+      method: 'POST',
+      body: JSON.stringify(issueData),
+    });
+
+    const jiraUrl = `${config.host}/browse/${result.key}`;
+
+    // Store the link in our database
+    const jiraIssue = await prisma.jiraIssue.create({
+      data: {
+        proposalId,
+        jiraKey: result.key,
+        jiraId: result.id,
+        jiraUrl,
+        issueType: config.issueType,
+        summary: proposal.title,
+        status: 'To Do',
+      },
+    });
+
+    logger.info(`Exported proposal ${proposalId} to Jira as ${result.key}`);
+
+    return {
+      id: jiraIssue.id,
+      jiraKey: result.key,
+      jiraUrl,
+    };
+  },
+
+  /**
+   * Sync the status of a Jira issue back to the local record.
+   */
+  async syncStatus(proposalId: string): Promise<{ jiraKey: string; status: string }> {
+    const config = await getJiraConfig();
+    const jiraIssue = await prisma.jiraIssue.findUnique({ where: { proposalId } });
+    if (!jiraIssue) throw NotFound('Jira issue for this proposal');
+
+    const issue = await jiraFetch<JiraIssueResponse>(
+      config,
+      `/issue/${encodeURIComponent(jiraIssue.jiraKey)}?fields=status,summary,issuetype`,
+    );
+
+    const updatedStatus = issue.fields.status.name;
+
+    await prisma.jiraIssue.update({
+      where: { proposalId },
+      data: {
+        status: updatedStatus,
+        summary: issue.fields.summary,
+        syncedAt: new Date(),
+      },
+    });
+
+    return { jiraKey: jiraIssue.jiraKey, status: updatedStatus };
+  },
+
+  /**
+   * Get the Jira issue linked to a proposal (if any).
+   */
+  async getByProposal(proposalId: string) {
+    return prisma.jiraIssue.findUnique({ where: { proposalId } });
+  },
+
+  /**
+   * List all exported Jira issues.
+   */
+  async listExported() {
+    return prisma.jiraIssue.findMany({
+      include: {
+        proposal: { select: { id: true, title: true, status: true, riceScore: true } },
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+  },
+
+  /**
+   * Unlink a Jira issue from a proposal (does not delete the Jira issue).
+   */
+  async unlink(proposalId: string): Promise<void> {
+    const jiraIssue = await prisma.jiraIssue.findUnique({ where: { proposalId } });
+    if (!jiraIssue) throw NotFound('Jira issue link for this proposal');
+    await prisma.jiraIssue.delete({ where: { proposalId } });
+    logger.info(`Unlinked Jira issue ${jiraIssue.jiraKey} from proposal ${proposalId}`);
+  },
+
+  // ─── Theme → Epic + Bulk Export ────────────────────────
+
+  /**
+   * Export a theme as a Jira Epic, then export all its proposals as Stories
+   * linked under that Epic. This is the "one-click roadmap push" feature.
+   */
+  async exportThemeAsEpic(themeId: string): Promise<{
+    epicKey: string;
+    epicUrl: string;
+    storiesCreated: number;
+    storiesSkipped: number;
+  }> {
+    const config = await getJiraConfig();
+    if (!config.projectKey) throw BadRequest('No Jira project key configured');
+
+    const theme = await prisma.theme.findUnique({
+      where: { id: themeId },
+      include: {
+        proposals: {
+          include: {
+            theme: { select: { name: true } },
+            jiraIssue: true,
+            evidence: {
+              take: 5,
+              orderBy: { relevanceScore: 'desc' },
+              include: {
+                feedbackItem: { select: { content: true, author: true, channel: true } },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!theme) throw NotFound('Theme');
+
+    // Check if epic already exists
+    if (theme.jiraEpicKey) {
+      throw BadRequest(`Theme already exported to Jira as Epic ${theme.jiraEpicKey}`);
+    }
+
+    // 1. Create Epic
+    const epicData = {
+      fields: {
+        project: { key: config.projectKey },
+        summary: theme.name,
+        description: buildEpicDescription(theme),
+        issuetype: { name: 'Epic' },
+        labels: ['shipscope', `category-${theme.category || 'general'}`],
+      },
+    };
+
+    const epicResult = await jiraFetch<JiraCreateResponse>(config, '/issue', {
+      method: 'POST',
+      body: JSON.stringify(epicData),
+    });
+
+    const epicUrl = `${config.host}/browse/${epicResult.key}`;
+
+    // Save Epic link on theme
+    await prisma.theme.update({
+      where: { id: themeId },
+      data: { jiraEpicKey: epicResult.key, jiraEpicUrl: epicUrl },
+    });
+
+    // 2. Create Stories for each proposal under the Epic
+    let storiesCreated = 0;
+    let storiesSkipped = 0;
+
+    for (const proposal of theme.proposals) {
+      if (proposal.jiraIssue) {
+        storiesSkipped++;
+        continue;
+      }
+
+      try {
+        const descriptionAdf = buildJiraDescription(proposal);
+
+        const storyData = {
+          fields: {
+            project: { key: config.projectKey },
+            summary: proposal.title,
+            description: descriptionAdf,
+            issuetype: { name: config.issueType || 'Story' },
+            labels: ['shipscope', `theme-${slugify(theme.name)}`],
+            parent: { key: epicResult.key },
+          },
+        };
+
+        const storyResult = await jiraFetch<JiraCreateResponse>(config, '/issue', {
+          method: 'POST',
+          body: JSON.stringify(storyData),
+        });
+
+        await prisma.jiraIssue.create({
+          data: {
+            proposalId: proposal.id,
+            jiraKey: storyResult.key,
+            jiraId: storyResult.id,
+            jiraUrl: `${config.host}/browse/${storyResult.key}`,
+            issueType: config.issueType || 'Story',
+            summary: proposal.title,
+            status: 'To Do',
+            epicKey: epicResult.key,
+          },
+        });
+
+        storiesCreated++;
+      } catch (err) {
+        logger.error(`Failed to create Jira story for proposal ${proposal.id}: ${err}`);
+        storiesSkipped++;
+      }
+    }
+
+    logger.info(
+      `Exported theme ${themeId} as Epic ${epicResult.key} with ${storiesCreated} stories`,
+    );
+
+    return {
+      epicKey: epicResult.key,
+      epicUrl,
+      storiesCreated,
+      storiesSkipped,
+    };
+  },
+
+  // ─── Spec Attachment ───────────────────────────────────
+
+  /**
+   * Attach the generated PRD spec as a comment on the linked Jira issue.
+   */
+  async attachSpec(proposalId: string): Promise<{ jiraKey: string; commented: boolean }> {
+    const config = await getJiraConfig();
+
+    const jiraIssue = await prisma.jiraIssue.findUnique({ where: { proposalId } });
+    if (!jiraIssue) throw NotFound('No Jira issue linked to this proposal');
+
+    const spec = await prisma.spec.findUnique({ where: { proposalId } });
+    if (!spec || !spec.prdMarkdown) throw BadRequest('No spec generated for this proposal');
+
+    // Add PRD as a comment (ADF format)
+    const commentBody = buildSpecComment(spec.prdMarkdown, spec.version);
+
+    await jiraFetch(config, `/issue/${encodeURIComponent(jiraIssue.jiraKey)}/comment`, {
+      method: 'POST',
+      body: JSON.stringify({ body: commentBody }),
+    });
+
+    logger.info(`Attached spec v${spec.version} to Jira issue ${jiraIssue.jiraKey}`);
+    return { jiraKey: jiraIssue.jiraKey, commented: true };
+  },
+
+  // ─── Jira → ShipScope Feedback Import ──────────────────
+
+  /**
+   * Import issues from a Jira project (bugs, stories with customer labels)
+   * as ShipScope feedback items. This creates a bi-directional flow.
+   */
+  async importFeedbackFromJira(
+    options: {
+      jql?: string;
+      maxResults?: number;
+    } = {},
+  ): Promise<{ imported: number; skipped: number; sourceId: string }> {
+    const config = await getJiraConfig();
+    if (!config.projectKey) throw BadRequest('No Jira project key configured');
+
+    const jql =
+      options.jql ||
+      `project = ${config.projectKey} AND type in (Bug, Story) AND status != Done ORDER BY created DESC`;
+    const maxResults = Math.min(options.maxResults || 50, 100);
+
+    const searchResult = await jiraFetch<{
+      issues: {
+        key: string;
+        fields: {
+          summary: string;
+          description?: unknown;
+          issuetype: { name: string };
+          reporter?: { displayName?: string; emailAddress?: string };
+          created: string;
+          labels: string[];
+          status: { name: string };
+        };
+      }[];
+      total: number;
+    }>(config, '/search/jql', {
+      method: 'POST',
+      body: JSON.stringify({
+        jql,
+        maxResults,
+        fields: ['summary', 'description', 'issuetype', 'reporter', 'created', 'labels', 'status'],
+      }),
+    });
+
+    // Create a feedback source for this import
+    const source = await prisma.feedbackSource.create({
+      data: {
+        name: `Jira Import (${config.projectKey})`,
+        type: 'jira',
+        metadata: { jql, projectKey: config.projectKey, importedAt: new Date().toISOString() },
+      },
+    });
+
+    let imported = 0;
+    let skipped = 0;
+
+    for (const issue of searchResult.issues) {
+      // Skip if already imported (check by metadata)
+      const existing = await prisma.feedbackItem.findFirst({
+        where: {
+          metadata: { path: ['jira_key'], equals: issue.key },
+        },
+      });
+
+      if (existing) {
+        skipped++;
+        continue;
+      }
+
+      const descriptionText = extractTextFromAdf(issue.fields.description);
+      const content = descriptionText
+        ? `[${issue.key}] ${issue.fields.summary}: ${descriptionText}`
+        : `[${issue.key}] ${issue.fields.summary}`;
+
+      await prisma.feedbackItem.create({
+        data: {
+          content: content.slice(0, 5000),
+          sourceId: source.id,
+          author: issue.fields.reporter?.displayName || null,
+          email: issue.fields.reporter?.emailAddress || null,
+          channel: `jira_${issue.fields.issuetype.name.toLowerCase()}`,
+          metadata: {
+            jira_key: issue.key,
+            jira_status: issue.fields.status.name,
+            jira_labels: issue.fields.labels,
+            jira_url: `${config.host}/browse/${issue.key}`,
+          },
+        },
+      });
+      imported++;
+    }
+
+    // Update source row count
+    await prisma.feedbackSource.update({
+      where: { id: source.id },
+      data: { rowCount: imported },
+    });
+
+    return { imported, skipped, sourceId: source.id };
+  },
+
+  // ─── Bulk Sync All Statuses ────────────────────────────
+
+  /**
+   * Sync status for ALL linked Jira issues. Also auto-updates
+   * proposal status when Jira issue reaches "Done".
+   */
+  async syncAllStatuses(): Promise<{
+    synced: number;
+    autoShipped: number;
+    errors: number;
+  }> {
+    const config = await getJiraConfig();
+    const allIssues = await prisma.jiraIssue.findMany({
+      include: { proposal: { select: { id: true, status: true } } },
+    });
+
+    let synced = 0;
+    let autoShipped = 0;
+    let errors = 0;
+
+    for (const jiraIssue of allIssues) {
+      try {
+        const issue = await jiraFetch<JiraIssueResponse>(
+          config,
+          `/issue/${encodeURIComponent(jiraIssue.jiraKey)}?fields=status,summary`,
+        );
+
+        const newStatus = issue.fields.status.name;
+
+        await prisma.jiraIssue.update({
+          where: { id: jiraIssue.id },
+          data: { status: newStatus, summary: issue.fields.summary, syncedAt: new Date() },
+        });
+
+        // Auto-mark proposal as "shipped" when Jira issue is Done
+        const doneStatuses = ['done', 'closed', 'resolved', 'released'];
+        if (
+          doneStatuses.includes(newStatus.toLowerCase()) &&
+          jiraIssue.proposal.status !== 'shipped'
+        ) {
+          await prisma.proposal.update({
+            where: { id: jiraIssue.proposal.id },
+            data: { status: 'shipped' },
+          });
+          autoShipped++;
+          logger.info(
+            `Auto-shipped proposal ${jiraIssue.proposal.id} (Jira ${jiraIssue.jiraKey} → ${newStatus})`,
+          );
+        }
+
+        synced++;
+      } catch (err) {
+        logger.error(`Failed to sync Jira issue ${jiraIssue.jiraKey}: ${err}`);
+        errors++;
+      }
+    }
+
+    return { synced, autoShipped, errors };
+  },
+
+  // ─── Jira Webhook Handler ──────────────────────────────
+
+  /**
+   * Handle incoming Jira webhooks for real-time status sync.
+   * Jira sends webhooks on issue:updated events.
+   */
+  async handleWebhook(payload: {
+    webhookEvent?: string;
+    issue?: {
+      key: string;
+      fields: {
+        status: { name: string };
+        summary: string;
+      };
+    };
+  }): Promise<{ processed: boolean; jiraKey?: string }> {
+    if (!payload.issue?.key) {
+      return { processed: false };
+    }
+
+    const jiraKey = payload.issue.key;
+    const jiraIssue = await prisma.jiraIssue.findUnique({ where: { jiraKey } });
+
+    if (!jiraIssue) {
+      // Not a tracked issue — ignore
+      return { processed: false };
+    }
+
+    const newStatus = payload.issue.fields.status.name;
+
+    await prisma.jiraIssue.update({
+      where: { jiraKey },
+      data: {
+        status: newStatus,
+        summary: payload.issue.fields.summary,
+        syncedAt: new Date(),
+      },
+    });
+
+    // Auto-ship proposal if Jira issue is done
+    const doneStatuses = ['done', 'closed', 'resolved', 'released'];
+    if (doneStatuses.includes(newStatus.toLowerCase())) {
+      const proposal = await prisma.proposal.findUnique({
+        where: { id: jiraIssue.proposalId },
+        select: { status: true },
+      });
+      if (proposal && proposal.status !== 'shipped') {
+        await prisma.proposal.update({
+          where: { id: jiraIssue.proposalId },
+          data: { status: 'shipped' },
+        });
+        logger.info(
+          `Webhook auto-shipped proposal ${jiraIssue.proposalId} (Jira ${jiraKey} → ${newStatus})`,
+        );
+      }
+    }
+
+    return { processed: true, jiraKey };
+  },
+
+  // ─── Dashboard Data ────────────────────────────────────
+
+  /**
+   * Get Jira sync summary for the dashboard widget.
+   */
+  async getDashboardSummary(): Promise<{
+    totalExported: number;
+    byStatus: Record<string, number>;
+    recentExports: {
+      jiraKey: string;
+      summary: string;
+      status: string;
+      jiraUrl: string;
+      createdAt: string;
+    }[];
+    epicCount: number;
+  }> {
+    const [allIssues, epicCount] = await Promise.all([
+      prisma.jiraIssue.findMany({
+        select: { jiraKey: true, summary: true, status: true, jiraUrl: true, createdAt: true },
+        orderBy: { createdAt: 'desc' },
+      }),
+      prisma.theme.count({ where: { jiraEpicKey: { not: null } } }),
+    ]);
+
+    const byStatus: Record<string, number> = {};
+    for (const issue of allIssues) {
+      byStatus[issue.status] = (byStatus[issue.status] || 0) + 1;
+    }
+
+    return {
+      totalExported: allIssues.length,
+      byStatus,
+      recentExports: allIssues
+        .slice(0, 5)
+        .map(
+          (i: {
+            jiraKey: string;
+            summary: string;
+            status: string;
+            jiraUrl: string;
+            createdAt: Date;
+          }) => ({
+            ...i,
+            createdAt: i.createdAt.toISOString(),
+          }),
+        ),
+      epicCount,
+    };
+  },
+};
+
+// ─── Helpers ──────────────────────────────────────────────
+
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 50);
+}
+
+interface ProposalWithEvidence {
+  title: string;
+  problem: string;
+  solution: string;
+  reachScore: number | null;
+  impactScore: number | null;
+  confidenceScore: number | null;
+  effortScore: number | null;
+  riceScore: number | null;
+  theme: { name: string } | null;
+  evidence: {
+    feedbackItem: { content: string; author: string | null; channel: string | null };
+  }[];
+}
+
+/**
+ * Build a Jira description using Atlassian Document Format (ADF).
+ */
+function buildJiraDescription(proposal: ProposalWithEvidence) {
+  const content: unknown[] = [];
+
+  // Problem section
+  content.push(heading('Problem'));
+  content.push(paragraph(proposal.problem));
+
+  // Solution section
+  content.push(heading('Solution'));
+  content.push(paragraph(proposal.solution));
+
+  // RICE scores
+  if (proposal.riceScore !== null) {
+    content.push(heading('RICE Score'));
+    const scores = [
+      `Reach: ${proposal.reachScore ?? '-'}`,
+      `Impact: ${proposal.impactScore ?? '-'}`,
+      `Confidence: ${proposal.confidenceScore ?? '-'}`,
+      `Effort: ${proposal.effortScore ?? '-'}`,
+      `Total: ${proposal.riceScore?.toFixed(1) ?? '-'}`,
+    ];
+    content.push({
+      type: 'bulletList',
+      content: scores.map((s) => ({
+        type: 'listItem',
+        content: [paragraph(s)],
+      })),
+    });
+  }
+
+  // Theme
+  if (proposal.theme) {
+    content.push(heading('Theme'));
+    content.push(paragraph(proposal.theme.name));
+  }
+
+  // Customer evidence
+  if (proposal.evidence.length > 0) {
+    content.push(heading('Customer Evidence'));
+    content.push({
+      type: 'bulletList',
+      content: proposal.evidence.map((ev) => ({
+        type: 'listItem',
+        content: [
+          paragraph(
+            `"${ev.feedbackItem.content.slice(0, 200)}"${ev.feedbackItem.author ? ` — ${ev.feedbackItem.author}` : ''}${ev.feedbackItem.channel ? ` (${ev.feedbackItem.channel})` : ''}`,
+          ),
+        ],
+      })),
+    });
+  }
+
+  // Generated by
+  content.push({
+    type: 'paragraph',
+    content: [
+      {
+        type: 'text',
+        text: 'Generated by ShipScope',
+        marks: [{ type: 'em' }],
+      },
+    ],
+  });
+
+  return {
+    type: 'doc',
+    version: 1,
+    content,
+  };
+}
+
+function heading(text: string) {
+  return {
+    type: 'heading',
+    attrs: { level: 3 },
+    content: [{ type: 'text', text }],
+  };
+}
+
+function paragraph(text: string) {
+  return {
+    type: 'paragraph',
+    content: [{ type: 'text', text }],
+  };
+}
+
+/**
+ * Build ADF description for a Jira Epic from a Theme.
+ */
+function buildEpicDescription(theme: {
+  name: string;
+  description: string;
+  feedbackCount: number;
+  avgSentiment: number;
+  opportunityScore: number;
+  category: string | null;
+}) {
+  const content: unknown[] = [];
+
+  content.push(heading('Theme Overview'));
+  content.push(paragraph(theme.description));
+
+  content.push(heading('Metrics'));
+  content.push({
+    type: 'bulletList',
+    content: [
+      `Feedback Count: ${theme.feedbackCount}`,
+      `Average Sentiment: ${theme.avgSentiment.toFixed(2)}`,
+      `Opportunity Score: ${theme.opportunityScore.toFixed(1)}`,
+      `Category: ${theme.category || 'Uncategorized'}`,
+    ].map((s) => ({
+      type: 'listItem',
+      content: [paragraph(s)],
+    })),
+  });
+
+  content.push({
+    type: 'paragraph',
+    content: [{ type: 'text', text: 'Generated by ShipScope', marks: [{ type: 'em' }] }],
+  });
+
+  return { type: 'doc', version: 1, content };
+}
+
+/**
+ * Build ADF comment body for attaching a spec/PRD.
+ */
+function buildSpecComment(prdMarkdown: string, version: number) {
+  const content: unknown[] = [];
+
+  content.push({
+    type: 'heading',
+    attrs: { level: 2 },
+    content: [{ type: 'text', text: `📋 PRD Spec (v${version}) — Generated by ShipScope` }],
+  });
+
+  // Convert markdown sections to ADF paragraphs
+  const lines = prdMarkdown.split('\n');
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    if (trimmed.startsWith('## ')) {
+      content.push(heading(trimmed.slice(3)));
+    } else if (trimmed.startsWith('# ')) {
+      content.push({
+        type: 'heading',
+        attrs: { level: 2 },
+        content: [{ type: 'text', text: trimmed.slice(2) }],
+      });
+    } else if (trimmed.startsWith('- ') || trimmed.startsWith('* ')) {
+      content.push({
+        type: 'bulletList',
+        content: [
+          {
+            type: 'listItem',
+            content: [paragraph(trimmed.slice(2))],
+          },
+        ],
+      });
+    } else {
+      content.push(paragraph(trimmed));
+    }
+  }
+
+  return { type: 'doc', version: 1, content };
+}
+
+/**
+ * Extract plain text from Jira's Atlassian Document Format (ADF).
+ * Used when importing Jira issues as feedback.
+ */
+function extractTextFromAdf(adf: unknown): string {
+  if (!adf || typeof adf !== 'object') return '';
+
+  const doc = adf as { content?: unknown[] };
+  if (!doc.content || !Array.isArray(doc.content)) return '';
+
+  const texts: string[] = [];
+
+  function walk(node: unknown) {
+    if (!node || typeof node !== 'object') return;
+    const n = node as { type?: string; text?: string; content?: unknown[] };
+    if (n.type === 'text' && n.text) {
+      texts.push(n.text);
+    }
+    if (n.content && Array.isArray(n.content)) {
+      n.content.forEach(walk);
+    }
+  }
+
+  doc.content.forEach(walk);
+  return texts.join(' ').slice(0, 2000);
+}

--- a/packages/api/src/services/proposal.service.ts
+++ b/packages/api/src/services/proposal.service.ts
@@ -96,7 +96,7 @@ export async function generateFromThemes(topN = 20): Promise<ProposalGenerationR
   });
 
   if (themes.length === 0) {
-    throw NotFound('No themes found. Run synthesis first.');
+    throw BadRequest('No themes found. Run synthesis first to discover themes from your feedback.');
   }
 
   const result: ProposalGenerationResult = {

--- a/packages/api/src/services/settings.service.ts
+++ b/packages/api/src/services/settings.service.ts
@@ -31,6 +31,11 @@ export const settingsService = {
       const key = result[SETTING_KEYS.OPENAI_API_KEY];
       result[SETTING_KEYS.OPENAI_API_KEY] = key.slice(0, 7) + '...' + key.slice(-4);
     }
+    // Mask the Jira API token
+    if (result['jira_api_token']) {
+      const token = result['jira_api_token'];
+      result['jira_api_token'] = token.slice(0, 4) + '...' + token.slice(-4);
+    }
     return result;
   },
 

--- a/packages/api/tests/helpers/factories.ts
+++ b/packages/api/tests/helpers/factories.ts
@@ -73,6 +73,21 @@ export async function createSpec(proposalId: string, overrides = {}) {
   });
 }
 
+export async function createJiraIssue(proposalId: string, overrides = {}) {
+  return prisma.jiraIssue.create({
+    data: {
+      proposalId,
+      jiraKey: 'PROJ-1',
+      jiraId: '10001',
+      jiraUrl: 'https://test.atlassian.net/browse/PROJ-1',
+      issueType: 'Story',
+      summary: 'Test Jira Issue',
+      status: 'To Do',
+      ...overrides,
+    },
+  });
+}
+
 // Create a full pipeline of test data
 export async function createFullPipelineData() {
   const source = await createFeedbackSource();

--- a/packages/api/tests/integration/jira.routes.test.ts
+++ b/packages/api/tests/integration/jira.routes.test.ts
@@ -1,0 +1,524 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import { createApp } from '../../src/index';
+import { prisma } from '../setup';
+import { createTheme, createProposal, createSpec, createJiraIssue } from '../helpers/factories';
+
+// Mock global fetch for Jira API calls (external service)
+function mockFetch(response: unknown, status = 200) {
+  return vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(response),
+    text: () => Promise.resolve(JSON.stringify(response)),
+  } as Response);
+}
+
+async function seedJiraConfig() {
+  const settings = {
+    jira_host: 'https://test.atlassian.net',
+    jira_email: 'user@example.com',
+    jira_api_token: 'test-api-token',
+    jira_project_key: 'PROJ',
+    jira_issue_type: 'Story',
+  };
+  for (const [key, value] of Object.entries(settings)) {
+    await prisma.setting.upsert({
+      where: { key },
+      update: { value },
+      create: { key, value },
+    });
+  }
+}
+
+const app = createApp();
+
+describe('Jira Routes', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ─── PUT /api/jira/config ──────────────────────────────
+
+  describe('PUT /api/jira/config', () => {
+    it('saves valid Jira config', async () => {
+      const res = await request(app)
+        .put('/api/jira/config')
+        .send({
+          jira_host: 'https://myco.atlassian.net',
+          jira_email: 'admin@myco.com',
+          jira_api_token: 'secret-token',
+          jira_project_key: 'MC',
+        })
+        .expect(200);
+
+      expect(res.body.data.saved).toBe(true);
+
+      // Verify persisted
+      const host = await prisma.setting.findUnique({ where: { key: 'jira_host' } });
+      expect(host!.value).toBe('https://myco.atlassian.net');
+    });
+
+    it('accepts partial config', async () => {
+      const res = await request(app)
+        .put('/api/jira/config')
+        .send({ jira_project_key: 'NEW' })
+        .expect(200);
+
+      expect(res.body.data.saved).toBe(true);
+    });
+
+    it('rejects non-HTTPS host', async () => {
+      await request(app)
+        .put('/api/jira/config')
+        .send({ jira_host: 'http://insecure.atlassian.net' })
+        .expect(400);
+    });
+
+    it('rejects invalid email', async () => {
+      await request(app).put('/api/jira/config').send({ jira_email: 'not-an-email' }).expect(400);
+    });
+  });
+
+  // ─── POST /api/jira/test ───────────────────────────────
+
+  describe('POST /api/jira/test', () => {
+    it('returns success when connection works', async () => {
+      await seedJiraConfig();
+      mockFetch({ serverTitle: 'Test Jira' });
+
+      const res = await request(app).post('/api/jira/test').expect(200);
+
+      expect(res.body.data.success).toBe(true);
+      expect(res.body.data.message).toContain('Test Jira');
+    });
+
+    it('returns failure when not configured', async () => {
+      const res = await request(app).post('/api/jira/test').expect(200);
+
+      expect(res.body.data.success).toBe(false);
+      expect(res.body.data.message).toContain('not configured');
+    });
+  });
+
+  // ─── GET /api/jira/projects ────────────────────────────
+
+  describe('GET /api/jira/projects', () => {
+    it('returns project list', async () => {
+      await seedJiraConfig();
+      mockFetch([
+        { id: '1', key: 'PROJ', name: 'Project' },
+        { id: '2', key: 'DEV', name: 'Development' },
+      ]);
+
+      const res = await request(app).get('/api/jira/projects').expect(200);
+
+      expect(res.body.data).toHaveLength(2);
+      expect(res.body.data[0].key).toBe('PROJ');
+    });
+  });
+
+  // ─── GET /api/jira/issue-types ─────────────────────────
+
+  describe('GET /api/jira/issue-types', () => {
+    it('returns filtered issue types', async () => {
+      await seedJiraConfig();
+      mockFetch({
+        issueTypes: [
+          { id: '1', name: 'Story', subtask: false },
+          { id: '2', name: 'Sub-task', subtask: true },
+        ],
+      });
+
+      const res = await request(app).get('/api/jira/issue-types').expect(200);
+
+      expect(res.body.data).toHaveLength(1);
+      expect(res.body.data[0].name).toBe('Story');
+    });
+  });
+
+  // ─── POST /api/jira/export/:proposalId ─────────────────
+
+  describe('POST /api/jira/export/:proposalId', () => {
+    it('exports proposal to Jira and returns 201', async () => {
+      await seedJiraConfig();
+      const theme = await createTheme();
+      const proposal = await createProposal(theme.id);
+      mockFetch({ id: '10001', key: 'PROJ-42', self: '' });
+
+      const res = await request(app).post(`/api/jira/export/${proposal.id}`).expect(201);
+
+      expect(res.body.data.jiraKey).toBe('PROJ-42');
+      expect(res.body.data.jiraUrl).toContain('browse/PROJ-42');
+
+      // Verify activity logged
+      const activity = await prisma.activityLog.findFirst({
+        where: { type: 'jira_export' },
+      });
+      expect(activity).not.toBeNull();
+      expect(activity!.description).toContain('PROJ-42');
+    });
+
+    it('returns 400 for already exported proposal', async () => {
+      await seedJiraConfig();
+      const theme = await createTheme();
+      const proposal = await createProposal(theme.id);
+      await createJiraIssue(proposal.id);
+
+      const res = await request(app).post(`/api/jira/export/${proposal.id}`).expect(400);
+
+      expect(res.body.error).toContain('already exported');
+    });
+
+    it('returns 404 for non-existent proposal', async () => {
+      await seedJiraConfig();
+      mockFetch({});
+
+      await request(app).post('/api/jira/export/nonexistent-id').expect(404);
+    });
+  });
+
+  // ─── POST /api/jira/sync/:proposalId ───────────────────
+
+  describe('POST /api/jira/sync/:proposalId', () => {
+    it('syncs status from Jira', async () => {
+      await seedJiraConfig();
+      const theme = await createTheme();
+      const proposal = await createProposal(theme.id);
+      await createJiraIssue(proposal.id);
+
+      mockFetch({
+        id: '10001',
+        key: 'PROJ-1',
+        fields: {
+          status: { name: 'In Progress' },
+          summary: 'Updated',
+          issuetype: { name: 'Story' },
+        },
+      });
+
+      const res = await request(app).post(`/api/jira/sync/${proposal.id}`).expect(200);
+
+      expect(res.body.data.status).toBe('In Progress');
+    });
+
+    it('returns 404 for unlinked proposal', async () => {
+      await seedJiraConfig();
+      const theme = await createTheme();
+      const proposal = await createProposal(theme.id);
+
+      await request(app).post(`/api/jira/sync/${proposal.id}`).expect(404);
+    });
+  });
+
+  // ─── GET /api/jira/issues ──────────────────────────────
+
+  describe('GET /api/jira/issues', () => {
+    it('returns empty list when nothing exported', async () => {
+      const res = await request(app).get('/api/jira/issues').expect(200);
+      expect(res.body.data).toEqual([]);
+    });
+
+    it('returns exported issues with proposal data', async () => {
+      const theme = await createTheme();
+      const proposal = await createProposal(theme.id, { title: 'My Feature' });
+      await createJiraIssue(proposal.id, { jiraKey: 'PROJ-5' });
+
+      const res = await request(app).get('/api/jira/issues').expect(200);
+
+      expect(res.body.data).toHaveLength(1);
+      expect(res.body.data[0].jiraKey).toBe('PROJ-5');
+      expect(res.body.data[0].proposal.title).toBe('My Feature');
+    });
+  });
+
+  // ─── GET /api/jira/issues/:proposalId ──────────────────
+
+  describe('GET /api/jira/issues/:proposalId', () => {
+    it('returns Jira issue for a proposal', async () => {
+      const theme = await createTheme();
+      const proposal = await createProposal(theme.id);
+      await createJiraIssue(proposal.id, { jiraKey: 'PROJ-99' });
+
+      const res = await request(app).get(`/api/jira/issues/${proposal.id}`).expect(200);
+
+      expect(res.body.data.jiraKey).toBe('PROJ-99');
+    });
+
+    it('returns null when no Jira issue is linked', async () => {
+      const theme = await createTheme();
+      const proposal = await createProposal(theme.id);
+
+      const res = await request(app).get(`/api/jira/issues/${proposal.id}`).expect(200);
+
+      expect(res.body.data).toBeNull();
+    });
+  });
+
+  // ─── DELETE /api/jira/issues/:proposalId ───────────────
+
+  describe('DELETE /api/jira/issues/:proposalId', () => {
+    it('unlinks Jira issue and returns 204', async () => {
+      const theme = await createTheme();
+      const proposal = await createProposal(theme.id);
+      await createJiraIssue(proposal.id);
+
+      await request(app).delete(`/api/jira/issues/${proposal.id}`).expect(204);
+
+      const issue = await prisma.jiraIssue.findUnique({ where: { proposalId: proposal.id } });
+      expect(issue).toBeNull();
+    });
+
+    it('returns 404 when no link exists', async () => {
+      const theme = await createTheme();
+      const proposal = await createProposal(theme.id);
+
+      await request(app).delete(`/api/jira/issues/${proposal.id}`).expect(404);
+    });
+  });
+
+  // ─── POST /api/jira/export-theme/:themeId ──────────────
+
+  describe('POST /api/jira/export-theme/:themeId', () => {
+    it('exports theme as epic with stories', async () => {
+      await seedJiraConfig();
+      const theme = await createTheme({ name: 'Perf Theme' });
+      await createProposal(theme.id, { title: 'Story 1' });
+
+      let callCount = 0;
+      vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
+        callCount++;
+        return {
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              id: `${callCount}`,
+              key: callCount === 1 ? 'PROJ-EPIC' : `PROJ-S${callCount}`,
+              self: '',
+            }),
+          text: () => Promise.resolve(''),
+        } as Response;
+      });
+
+      const res = await request(app).post(`/api/jira/export-theme/${theme.id}`).expect(201);
+
+      expect(res.body.data.epicKey).toBe('PROJ-EPIC');
+      expect(res.body.data.storiesCreated).toBe(1);
+
+      // Verify activity logged
+      const activity = await prisma.activityLog.findFirst({
+        where: { type: 'jira_export' },
+      });
+      expect(activity).not.toBeNull();
+      expect(activity!.description).toContain('Epic');
+    });
+
+    it('returns 400 for theme with existing epic', async () => {
+      await seedJiraConfig();
+      const theme = await createTheme({ jiraEpicKey: 'PROJ-OLD' });
+
+      const res = await request(app).post(`/api/jira/export-theme/${theme.id}`).expect(400);
+
+      expect(res.body.error).toContain('already exported');
+    });
+  });
+
+  // ─── POST /api/jira/attach-spec/:proposalId ───────────
+
+  describe('POST /api/jira/attach-spec/:proposalId', () => {
+    it('attaches spec as Jira comment', async () => {
+      await seedJiraConfig();
+      const theme = await createTheme();
+      const proposal = await createProposal(theme.id);
+      await createJiraIssue(proposal.id, { jiraKey: 'PROJ-10' });
+      await createSpec(proposal.id);
+      mockFetch({});
+
+      const res = await request(app).post(`/api/jira/attach-spec/${proposal.id}`).expect(200);
+
+      expect(res.body.data.jiraKey).toBe('PROJ-10');
+      expect(res.body.data.commented).toBe(true);
+    });
+
+    it('returns 404 when no Jira issue linked', async () => {
+      await seedJiraConfig();
+      const theme = await createTheme();
+      const proposal = await createProposal(theme.id);
+
+      await request(app).post(`/api/jira/attach-spec/${proposal.id}`).expect(404);
+    });
+
+    it('returns 400 when no spec exists', async () => {
+      await seedJiraConfig();
+      const theme = await createTheme();
+      const proposal = await createProposal(theme.id);
+      await createJiraIssue(proposal.id);
+
+      await request(app).post(`/api/jira/attach-spec/${proposal.id}`).expect(400);
+    });
+  });
+
+  // ─── POST /api/jira/import-feedback ────────────────────
+
+  describe('POST /api/jira/import-feedback', () => {
+    it('imports Jira issues as feedback with 201', async () => {
+      await seedJiraConfig();
+      mockFetch({
+        issues: [
+          {
+            key: 'PROJ-100',
+            fields: {
+              summary: 'Bug report',
+              description: null,
+              issuetype: { name: 'Bug' },
+              reporter: { displayName: 'Alice' },
+              created: '2024-01-01T00:00:00.000Z',
+              labels: [],
+              status: { name: 'Open' },
+            },
+          },
+        ],
+        total: 1,
+      });
+
+      const res = await request(app)
+        .post('/api/jira/import-feedback')
+        .send({ jql: 'project = PROJ', maxResults: 10 })
+        .expect(201);
+
+      expect(res.body.data.imported).toBe(1);
+      expect(res.body.data.skipped).toBe(0);
+
+      // Verify activity logged
+      const activity = await prisma.activityLog.findFirst({
+        where: { type: 'import' },
+      });
+      expect(activity).not.toBeNull();
+      expect(activity!.description).toContain('Jira');
+    });
+
+    it('handles empty results', async () => {
+      await seedJiraConfig();
+      mockFetch({ issues: [], total: 0 });
+
+      const res = await request(app).post('/api/jira/import-feedback').send({}).expect(201);
+
+      expect(res.body.data.imported).toBe(0);
+    });
+  });
+
+  // ─── POST /api/jira/sync-all ───────────────────────────
+
+  describe('POST /api/jira/sync-all', () => {
+    it('syncs all linked issues', async () => {
+      await seedJiraConfig();
+      const theme = await createTheme();
+      const p1 = await createProposal(theme.id);
+      const p2 = await createProposal(theme.id);
+      await createJiraIssue(p1.id, { jiraKey: 'PROJ-1' });
+      await createJiraIssue(p2.id, { jiraKey: 'PROJ-2' });
+
+      vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+        const key = String(url).includes('PROJ-1') ? 'PROJ-1' : 'PROJ-2';
+        return {
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              id: '1',
+              key,
+              fields: { status: { name: 'Done' }, summary: `${key} done` },
+            }),
+          text: () => Promise.resolve(''),
+        } as Response;
+      });
+
+      const res = await request(app).post('/api/jira/sync-all').expect(200);
+
+      expect(res.body.data.synced).toBe(2);
+      expect(res.body.data.autoShipped).toBe(2);
+    });
+
+    it('returns zeros when nothing to sync', async () => {
+      await seedJiraConfig();
+
+      const res = await request(app).post('/api/jira/sync-all').expect(200);
+
+      expect(res.body.data.synced).toBe(0);
+      expect(res.body.data.errors).toBe(0);
+    });
+  });
+
+  // ─── POST /api/jira/webhook ────────────────────────────
+
+  describe('POST /api/jira/webhook', () => {
+    it('processes webhook for tracked issue', async () => {
+      const theme = await createTheme();
+      const proposal = await createProposal(theme.id);
+      await createJiraIssue(proposal.id, { jiraKey: 'PROJ-50' });
+
+      const res = await request(app)
+        .post('/api/jira/webhook')
+        .send({
+          webhookEvent: 'jira:issue_updated',
+          issue: {
+            key: 'PROJ-50',
+            fields: { status: { name: 'In Review' }, summary: 'Updated' },
+          },
+        })
+        .expect(200);
+
+      expect(res.body.data.processed).toBe(true);
+    });
+
+    it('ignores untracked issues', async () => {
+      const res = await request(app)
+        .post('/api/jira/webhook')
+        .send({
+          issue: {
+            key: 'UNKNOWN-1',
+            fields: { status: { name: 'Done' }, summary: 'Unknown' },
+          },
+        })
+        .expect(200);
+
+      expect(res.body.data.processed).toBe(false);
+    });
+
+    it('ignores empty payload', async () => {
+      const res = await request(app).post('/api/jira/webhook').send({}).expect(200);
+
+      expect(res.body.data.processed).toBe(false);
+    });
+  });
+
+  // ─── GET /api/jira/dashboard ───────────────────────────
+
+  describe('GET /api/jira/dashboard', () => {
+    it('returns empty summary', async () => {
+      const res = await request(app).get('/api/jira/dashboard').expect(200);
+
+      expect(res.body.data.totalExported).toBe(0);
+      expect(res.body.data.byStatus).toEqual({});
+      expect(res.body.data.recentExports).toEqual([]);
+      expect(res.body.data.epicCount).toBe(0);
+    });
+
+    it('returns populated summary', async () => {
+      const theme = await createTheme({ jiraEpicKey: 'PROJ-EPIC' });
+      const p1 = await createProposal(theme.id);
+      const p2 = await createProposal(theme.id);
+      await createJiraIssue(p1.id, { jiraKey: 'PROJ-1', status: 'To Do' });
+      await createJiraIssue(p2.id, { jiraKey: 'PROJ-2', status: 'Done' });
+
+      const res = await request(app).get('/api/jira/dashboard').expect(200);
+
+      expect(res.body.data.totalExported).toBe(2);
+      expect(res.body.data.byStatus['To Do']).toBe(1);
+      expect(res.body.data.byStatus['Done']).toBe(1);
+      expect(res.body.data.recentExports).toHaveLength(2);
+      expect(res.body.data.epicCount).toBe(1);
+    });
+  });
+});

--- a/packages/api/tests/setup.ts
+++ b/packages/api/tests/setup.ts
@@ -16,6 +16,7 @@ beforeAll(async () => {
 beforeEach(async () => {
   // Clean all tables in dependency order (child tables first)
   await prisma.$transaction([
+    prisma.jiraIssue.deleteMany(),
     prisma.proposalEvidence.deleteMany(),
     prisma.spec.deleteMany(),
     prisma.proposal.deleteMany(),

--- a/packages/api/tests/unit/jira-schema.test.ts
+++ b/packages/api/tests/unit/jira-schema.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { exportToJiraSchema, jiraConfigSchema } from '../../src/schemas/jira.schema';
+
+describe('Jira Schemas', () => {
+  describe('exportToJiraSchema', () => {
+    it('accepts valid proposal ID', () => {
+      const result = exportToJiraSchema.safeParse({ proposalId: 'abc-123' });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects empty proposal ID', () => {
+      const result = exportToJiraSchema.safeParse({ proposalId: '' });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects missing proposal ID', () => {
+      const result = exportToJiraSchema.safeParse({});
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('jiraConfigSchema', () => {
+    it('accepts valid full config', () => {
+      const result = jiraConfigSchema.safeParse({
+        jira_host: 'https://mycompany.atlassian.net',
+        jira_email: 'user@example.com',
+        jira_api_token: 'abc123token',
+        jira_project_key: 'PROJ',
+        jira_issue_type: 'Story',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts partial config (all fields optional)', () => {
+      const result = jiraConfigSchema.safeParse({
+        jira_host: 'https://mycompany.atlassian.net',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts empty object', () => {
+      const result = jiraConfigSchema.safeParse({});
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects non-HTTPS host', () => {
+      const result = jiraConfigSchema.safeParse({
+        jira_host: 'http://mycompany.atlassian.net',
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].message).toContain('HTTPS');
+      }
+    });
+
+    it('rejects invalid URL for host', () => {
+      const result = jiraConfigSchema.safeParse({
+        jira_host: 'not-a-url',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects invalid email', () => {
+      const result = jiraConfigSchema.safeParse({
+        jira_email: 'not-an-email',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects empty API token', () => {
+      const result = jiraConfigSchema.safeParse({
+        jira_api_token: '',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects project key longer than 20 chars', () => {
+      const result = jiraConfigSchema.safeParse({
+        jira_project_key: 'A'.repeat(21),
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects issue type longer than 50 chars', () => {
+      const result = jiraConfigSchema.safeParse({
+        jira_issue_type: 'A'.repeat(51),
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/packages/api/tests/unit/jira-service.test.ts
+++ b/packages/api/tests/unit/jira-service.test.ts
@@ -1,0 +1,697 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { prisma } from '../setup';
+import {
+  createTheme,
+  createProposal,
+  createSpec,
+  createFeedbackSource,
+  createFeedbackItem,
+  createJiraIssue,
+} from '../helpers/factories';
+import { jiraService, JIRA_SETTING_KEYS } from '../../src/services/jira.service';
+
+// Helper to seed Jira config settings in the database
+async function seedJiraConfig(overrides: Record<string, string> = {}) {
+  const defaults: Record<string, string> = {
+    [JIRA_SETTING_KEYS.JIRA_HOST]: 'https://test.atlassian.net',
+    [JIRA_SETTING_KEYS.JIRA_EMAIL]: 'user@example.com',
+    [JIRA_SETTING_KEYS.JIRA_API_TOKEN]: 'test-api-token',
+    [JIRA_SETTING_KEYS.JIRA_PROJECT_KEY]: 'PROJ',
+    [JIRA_SETTING_KEYS.JIRA_ISSUE_TYPE]: 'Story',
+    ...overrides,
+  };
+  for (const [key, value] of Object.entries(defaults)) {
+    await prisma.setting.upsert({
+      where: { key },
+      update: { value },
+      create: { key, value },
+    });
+  }
+}
+
+// Mock global fetch for Jira API calls
+function mockFetch(response: unknown, status = 200) {
+  return vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(response),
+    text: () => Promise.resolve(JSON.stringify(response)),
+  } as Response);
+}
+
+describe('Jira Service', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ─── testConnection ─────────────────────────────────────
+
+  describe('testConnection', () => {
+    it('returns success when Jira API responds', async () => {
+      await seedJiraConfig();
+      mockFetch({ serverTitle: 'My Jira', baseUrl: 'https://test.atlassian.net' });
+
+      const result = await jiraService.testConnection();
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('My Jira');
+      expect(result.serverTitle).toBe('My Jira');
+    });
+
+    it('returns failure when Jira is not configured', async () => {
+      // No config saved - getJiraConfig should throw
+      const result = await jiraService.testConnection();
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('not configured');
+    });
+
+    it('returns failure when Jira API rejects credentials', async () => {
+      await seedJiraConfig();
+      mockFetch({ message: 'Unauthorized' }, 401);
+
+      const result = await jiraService.testConnection();
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('401');
+    });
+  });
+
+  // ─── listProjects ──────────────────────────────────────
+
+  describe('listProjects', () => {
+    it('returns mapped project list', async () => {
+      await seedJiraConfig();
+      mockFetch([
+        { id: '1', key: 'PROJ', name: 'Project One', extra: 'ignored' },
+        { id: '2', key: 'DEV', name: 'Dev Project' },
+      ]);
+
+      const projects = await jiraService.listProjects();
+      expect(projects).toHaveLength(2);
+      expect(projects[0]).toEqual({ id: '1', key: 'PROJ', name: 'Project One' });
+      expect(projects[1]).toEqual({ id: '2', key: 'DEV', name: 'Dev Project' });
+    });
+
+    it('throws when not configured', async () => {
+      await expect(jiraService.listProjects()).rejects.toThrow('not configured');
+    });
+  });
+
+  // ─── listIssueTypes ────────────────────────────────────
+
+  describe('listIssueTypes', () => {
+    it('returns non-subtask issue types', async () => {
+      await seedJiraConfig();
+      mockFetch({
+        issueTypes: [
+          { id: '1', name: 'Story', subtask: false },
+          { id: '2', name: 'Sub-task', subtask: true },
+          { id: '3', name: 'Bug', subtask: false },
+        ],
+      });
+
+      const types = await jiraService.listIssueTypes();
+      expect(types).toHaveLength(2);
+      expect(types.map((t) => t.name)).toEqual(['Story', 'Bug']);
+    });
+
+    it('throws when no project key configured', async () => {
+      await seedJiraConfig({ [JIRA_SETTING_KEYS.JIRA_PROJECT_KEY]: '' });
+      await expect(jiraService.listIssueTypes()).rejects.toThrow('project key');
+    });
+  });
+
+  // ─── exportProposal ────────────────────────────────────
+
+  describe('exportProposal', () => {
+    it('creates a Jira issue and stores the link', async () => {
+      await seedJiraConfig();
+      const theme = await createTheme();
+      const proposal = await createProposal(theme.id);
+
+      mockFetch({
+        id: '10001',
+        key: 'PROJ-42',
+        self: 'https://test.atlassian.net/rest/api/3/issue/10001',
+      });
+
+      const result = await jiraService.exportProposal(proposal.id);
+      expect(result.jiraKey).toBe('PROJ-42');
+      expect(result.jiraUrl).toBe('https://test.atlassian.net/browse/PROJ-42');
+
+      // Verify persisted in DB
+      const stored = await prisma.jiraIssue.findUnique({ where: { proposalId: proposal.id } });
+      expect(stored).not.toBeNull();
+      expect(stored!.jiraKey).toBe('PROJ-42');
+      expect(stored!.status).toBe('To Do');
+    });
+
+    it('throws when proposal is already exported', async () => {
+      await seedJiraConfig();
+      const theme = await createTheme();
+      const proposal = await createProposal(theme.id);
+      await createJiraIssue(proposal.id);
+
+      await expect(jiraService.exportProposal(proposal.id)).rejects.toThrow('already exported');
+    });
+
+    it('throws when proposal not found', async () => {
+      await seedJiraConfig();
+      await expect(jiraService.exportProposal('nonexistent-id')).rejects.toThrow('not found');
+    });
+
+    it('throws when no project key configured', async () => {
+      await seedJiraConfig({ [JIRA_SETTING_KEYS.JIRA_PROJECT_KEY]: '' });
+      const theme = await createTheme();
+      const proposal = await createProposal(theme.id);
+
+      await expect(jiraService.exportProposal(proposal.id)).rejects.toThrow('project key');
+    });
+
+    it('sends correct request to Jira API', async () => {
+      await seedJiraConfig();
+      const theme = await createTheme({ name: 'Performance Issues' });
+      const proposal = await createProposal(theme.id, {
+        title: 'Optimize Database Queries',
+        problem: 'Slow queries',
+        solution: 'Add indexes',
+      });
+
+      const fetchSpy = mockFetch({ id: '10001', key: 'PROJ-1', self: '' });
+
+      await jiraService.exportProposal(proposal.id);
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const [url, options] = fetchSpy.mock.calls[0];
+      expect(url).toBe('https://test.atlassian.net/rest/api/3/issue');
+      expect(options?.method).toBe('POST');
+
+      const body = JSON.parse(options?.body as string);
+      expect(body.fields.project.key).toBe('PROJ');
+      expect(body.fields.summary).toBe('Optimize Database Queries');
+      expect(body.fields.issuetype.name).toBe('Story');
+      expect(body.fields.labels).toContain('shipscope');
+      expect(body.fields.labels).toContain('theme-performance-issues');
+    });
+  });
+
+  // ─── syncStatus ────────────────────────────────────────
+
+  describe('syncStatus', () => {
+    it('updates local issue status from Jira', async () => {
+      await seedJiraConfig();
+      const theme = await createTheme();
+      const proposal = await createProposal(theme.id);
+      await createJiraIssue(proposal.id, { status: 'To Do' });
+
+      mockFetch({
+        id: '10001',
+        key: 'PROJ-1',
+        fields: {
+          status: { name: 'In Progress' },
+          summary: 'Updated Summary',
+          issuetype: { name: 'Story' },
+        },
+      });
+
+      const result = await jiraService.syncStatus(proposal.id);
+      expect(result.status).toBe('In Progress');
+
+      const updated = await prisma.jiraIssue.findUnique({ where: { proposalId: proposal.id } });
+      expect(updated!.status).toBe('In Progress');
+      expect(updated!.summary).toBe('Updated Summary');
+      expect(updated!.syncedAt).not.toBeNull();
+    });
+
+    it('throws when no Jira issue is linked', async () => {
+      await seedJiraConfig();
+      const theme = await createTheme();
+      const proposal = await createProposal(theme.id);
+
+      await expect(jiraService.syncStatus(proposal.id)).rejects.toThrow('not found');
+    });
+  });
+
+  // ─── getByProposal ────────────────────────────────────
+
+  describe('getByProposal', () => {
+    it('returns Jira issue when linked', async () => {
+      const theme = await createTheme();
+      const proposal = await createProposal(theme.id);
+      await createJiraIssue(proposal.id, { jiraKey: 'PROJ-99' });
+
+      const issue = await jiraService.getByProposal(proposal.id);
+      expect(issue).not.toBeNull();
+      expect(issue!.jiraKey).toBe('PROJ-99');
+    });
+
+    it('returns null when no link exists', async () => {
+      const theme = await createTheme();
+      const proposal = await createProposal(theme.id);
+
+      const issue = await jiraService.getByProposal(proposal.id);
+      expect(issue).toBeNull();
+    });
+  });
+
+  // ─── listExported ──────────────────────────────────────
+
+  describe('listExported', () => {
+    it('returns empty array when nothing exported', async () => {
+      const issues = await jiraService.listExported();
+      expect(issues).toEqual([]);
+    });
+
+    it('returns exported issues with proposal data', async () => {
+      const theme = await createTheme();
+      const proposal = await createProposal(theme.id, { title: 'My Proposal' });
+      await createJiraIssue(proposal.id, { jiraKey: 'PROJ-5' });
+
+      const issues = await jiraService.listExported();
+      expect(issues).toHaveLength(1);
+      expect(issues[0].jiraKey).toBe('PROJ-5');
+      expect(issues[0].proposal.title).toBe('My Proposal');
+    });
+
+    it('returns issues ordered by creation date descending', async () => {
+      const theme = await createTheme();
+      const p1 = await createProposal(theme.id, { title: 'First' });
+      const p2 = await createProposal(theme.id, { title: 'Second' });
+      const older = new Date('2024-01-01');
+      const newer = new Date('2024-06-01');
+      await createJiraIssue(p1.id, { jiraKey: 'PROJ-1', createdAt: older });
+      await createJiraIssue(p2.id, { jiraKey: 'PROJ-2', createdAt: newer });
+
+      const issues = await jiraService.listExported();
+      expect(issues).toHaveLength(2);
+      // Most recent first
+      expect(issues[0].jiraKey).toBe('PROJ-2');
+    });
+  });
+
+  // ─── unlink ────────────────────────────────────────────
+
+  describe('unlink', () => {
+    it('deletes the Jira issue link', async () => {
+      const theme = await createTheme();
+      const proposal = await createProposal(theme.id);
+      await createJiraIssue(proposal.id);
+
+      await jiraService.unlink(proposal.id);
+
+      const issue = await prisma.jiraIssue.findUnique({ where: { proposalId: proposal.id } });
+      expect(issue).toBeNull();
+    });
+
+    it('throws when no link exists', async () => {
+      const theme = await createTheme();
+      const proposal = await createProposal(theme.id);
+
+      await expect(jiraService.unlink(proposal.id)).rejects.toThrow('not found');
+    });
+  });
+
+  // ─── exportThemeAsEpic ─────────────────────────────────
+
+  describe('exportThemeAsEpic', () => {
+    it('creates an epic and stories for proposals', async () => {
+      await seedJiraConfig();
+      const theme = await createTheme({ name: 'Dashboard Redesign' });
+      await createProposal(theme.id, { title: 'Widget A' });
+      await createProposal(theme.id, { title: 'Widget B' });
+
+      let callCount = 0;
+      vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
+        callCount++;
+        const key = callCount === 1 ? 'PROJ-EPIC-1' : `PROJ-${callCount}`;
+        return {
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ id: `1000${callCount}`, key, self: '' }),
+          text: () => Promise.resolve(''),
+        } as Response;
+      });
+
+      const result = await jiraService.exportThemeAsEpic(theme.id);
+      expect(result.epicKey).toBe('PROJ-EPIC-1');
+      expect(result.epicUrl).toBe('https://test.atlassian.net/browse/PROJ-EPIC-1');
+      expect(result.storiesCreated).toBe(2);
+      expect(result.storiesSkipped).toBe(0);
+
+      // Verify theme updated
+      const updatedTheme = await prisma.theme.findUnique({ where: { id: theme.id } });
+      expect(updatedTheme!.jiraEpicKey).toBe('PROJ-EPIC-1');
+      expect(updatedTheme!.jiraEpicUrl).toBe('https://test.atlassian.net/browse/PROJ-EPIC-1');
+
+      // Verify stories created in DB
+      const issues = await prisma.jiraIssue.findMany();
+      expect(issues).toHaveLength(2);
+      expect(issues.every((i) => i.epicKey === 'PROJ-EPIC-1')).toBe(true);
+    });
+
+    it('skips proposals already exported', async () => {
+      await seedJiraConfig();
+      const theme = await createTheme();
+      const alreadyExported = await createProposal(theme.id, { title: 'Already Exported' });
+      await createProposal(theme.id, { title: 'New One' });
+      await createJiraIssue(alreadyExported.id, { jiraKey: 'PROJ-OLD' });
+
+      let callCount = 0;
+      vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
+        callCount++;
+        const key = callCount === 1 ? 'PROJ-EPIC' : `PROJ-NEW-${callCount}`;
+        return {
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ id: `2000${callCount}`, key, self: '' }),
+          text: () => Promise.resolve(''),
+        } as Response;
+      });
+
+      const result = await jiraService.exportThemeAsEpic(theme.id);
+      expect(result.storiesCreated).toBe(1);
+      expect(result.storiesSkipped).toBe(1);
+    });
+
+    it('throws when theme already has an epic', async () => {
+      await seedJiraConfig();
+      const theme = await createTheme({ jiraEpicKey: 'PROJ-EPIC-EXISTING' });
+
+      await expect(jiraService.exportThemeAsEpic(theme.id)).rejects.toThrow('already exported');
+    });
+
+    it('throws when theme not found', async () => {
+      await seedJiraConfig();
+      await expect(jiraService.exportThemeAsEpic('nonexistent')).rejects.toThrow('not found');
+    });
+  });
+
+  // ─── attachSpec ────────────────────────────────────────
+
+  describe('attachSpec', () => {
+    it('posts spec as comment to Jira issue', async () => {
+      await seedJiraConfig();
+      const theme = await createTheme();
+      const proposal = await createProposal(theme.id);
+      await createJiraIssue(proposal.id, { jiraKey: 'PROJ-10' });
+      await createSpec(proposal.id, { prdMarkdown: '# Test PRD\n\nContent here', version: 2 });
+
+      const fetchSpy = mockFetch({});
+
+      const result = await jiraService.attachSpec(proposal.id);
+      expect(result.jiraKey).toBe('PROJ-10');
+      expect(result.commented).toBe(true);
+
+      // Verify API call
+      const [url, options] = fetchSpy.mock.calls[0];
+      expect(url).toContain('/issue/PROJ-10/comment');
+      expect(options?.method).toBe('POST');
+      const body = JSON.parse(options?.body as string);
+      expect(body.body.type).toBe('doc');
+    });
+
+    it('throws when no Jira issue is linked', async () => {
+      await seedJiraConfig();
+      const theme = await createTheme();
+      const proposal = await createProposal(theme.id);
+
+      await expect(jiraService.attachSpec(proposal.id)).rejects.toThrow('No Jira issue');
+    });
+
+    it('throws when no spec exists', async () => {
+      await seedJiraConfig();
+      const theme = await createTheme();
+      const proposal = await createProposal(theme.id);
+      await createJiraIssue(proposal.id);
+
+      await expect(jiraService.attachSpec(proposal.id)).rejects.toThrow('No spec');
+    });
+  });
+
+  // ─── importFeedbackFromJira ────────────────────────────
+
+  describe('importFeedbackFromJira', () => {
+    it('imports issues as feedback items', async () => {
+      await seedJiraConfig();
+      mockFetch({
+        issues: [
+          {
+            key: 'PROJ-100',
+            fields: {
+              summary: 'Bug in login',
+              description: null,
+              issuetype: { name: 'Bug' },
+              reporter: { displayName: 'Jane Doe', emailAddress: 'jane@test.com' },
+              created: '2024-01-01T00:00:00.000Z',
+              labels: ['customer'],
+              status: { name: 'Open' },
+            },
+          },
+          {
+            key: 'PROJ-101',
+            fields: {
+              summary: 'Feature request for dashboard',
+              description: {
+                type: 'doc',
+                version: 1,
+                content: [
+                  { type: 'paragraph', content: [{ type: 'text', text: 'We need charts.' }] },
+                ],
+              },
+              issuetype: { name: 'Story' },
+              reporter: { displayName: 'John', emailAddress: 'john@test.com' },
+              created: '2024-01-02T00:00:00.000Z',
+              labels: [],
+              status: { name: 'Backlog' },
+            },
+          },
+        ],
+        total: 2,
+      });
+
+      const result = await jiraService.importFeedbackFromJira();
+      expect(result.imported).toBe(2);
+      expect(result.skipped).toBe(0);
+      expect(result.sourceId).toBeDefined();
+
+      // Verify feedback items created
+      const items = await prisma.feedbackItem.findMany({ orderBy: { createdAt: 'asc' } });
+      expect(items).toHaveLength(2);
+      expect(items[0].content).toContain('PROJ-100');
+      expect(items[0].content).toContain('Bug in login');
+      expect(items[0].author).toBe('Jane Doe');
+      expect(items[0].channel).toBe('jira_bug');
+
+      expect(items[1].content).toContain('We need charts.');
+      expect(items[1].channel).toBe('jira_story');
+
+      // Verify source created
+      const source = await prisma.feedbackSource.findUnique({ where: { id: result.sourceId } });
+      expect(source).not.toBeNull();
+      expect(source!.type).toBe('jira');
+      expect(source!.rowCount).toBe(2);
+    });
+
+    it('skips already imported issues', async () => {
+      await seedJiraConfig();
+
+      // Create an already-imported feedback item
+      const source = await createFeedbackSource({ type: 'jira' });
+      await createFeedbackItem(source.id, {
+        content: '[PROJ-100] Bug in login',
+        metadata: { jira_key: 'PROJ-100' },
+      });
+
+      mockFetch({
+        issues: [
+          {
+            key: 'PROJ-100',
+            fields: {
+              summary: 'Bug in login',
+              description: null,
+              issuetype: { name: 'Bug' },
+              reporter: null,
+              created: '2024-01-01T00:00:00.000Z',
+              labels: [],
+              status: { name: 'Open' },
+            },
+          },
+        ],
+        total: 1,
+      });
+
+      const result = await jiraService.importFeedbackFromJira();
+      expect(result.imported).toBe(0);
+      expect(result.skipped).toBe(1);
+    });
+
+    it('uses custom JQL when provided', async () => {
+      await seedJiraConfig();
+      const fetchSpy = mockFetch({ issues: [], total: 0 });
+
+      await jiraService.importFeedbackFromJira({ jql: 'labels = "customer-request"' });
+
+      const body = JSON.parse(fetchSpy.mock.calls[0][1]?.body as string);
+      expect(body.jql).toBe('labels = "customer-request"');
+    });
+
+    it('caps maxResults at 100', async () => {
+      await seedJiraConfig();
+      const fetchSpy = mockFetch({ issues: [], total: 0 });
+
+      await jiraService.importFeedbackFromJira({ maxResults: 500 });
+
+      const body = JSON.parse(fetchSpy.mock.calls[0][1]?.body as string);
+      expect(body.maxResults).toBe(100);
+    });
+
+    it('throws when no project key configured', async () => {
+      await seedJiraConfig({ [JIRA_SETTING_KEYS.JIRA_PROJECT_KEY]: '' });
+      await expect(jiraService.importFeedbackFromJira()).rejects.toThrow('project key');
+    });
+  });
+
+  // ─── handleWebhook ────────────────────────────────────
+
+  describe('handleWebhook', () => {
+    it('updates status for a tracked issue', async () => {
+      const theme = await createTheme();
+      const proposal = await createProposal(theme.id);
+      await createJiraIssue(proposal.id, { jiraKey: 'PROJ-50', status: 'To Do' });
+
+      const result = await jiraService.handleWebhook({
+        webhookEvent: 'jira:issue_updated',
+        issue: {
+          key: 'PROJ-50',
+          fields: { status: { name: 'In Review' }, summary: 'Updated title' },
+        },
+      });
+
+      expect(result.processed).toBe(true);
+      expect(result.jiraKey).toBe('PROJ-50');
+
+      const updated = await prisma.jiraIssue.findUnique({ where: { jiraKey: 'PROJ-50' } });
+      expect(updated!.status).toBe('In Review');
+      expect(updated!.summary).toBe('Updated title');
+    });
+
+    it('auto-ships proposal when Jira status is Done', async () => {
+      const theme = await createTheme();
+      const proposal = await createProposal(theme.id, { status: 'approved' });
+      await createJiraIssue(proposal.id, { jiraKey: 'PROJ-60' });
+
+      await jiraService.handleWebhook({
+        issue: {
+          key: 'PROJ-60',
+          fields: { status: { name: 'Done' }, summary: 'Completed' },
+        },
+      });
+
+      const updatedProposal = await prisma.proposal.findUnique({ where: { id: proposal.id } });
+      expect(updatedProposal!.status).toBe('shipped');
+    });
+
+    it('auto-ships for other done-like statuses', async () => {
+      const theme = await createTheme();
+      const proposal = await createProposal(theme.id, { status: 'approved' });
+      await createJiraIssue(proposal.id, { jiraKey: 'PROJ-70' });
+
+      await jiraService.handleWebhook({
+        issue: {
+          key: 'PROJ-70',
+          fields: { status: { name: 'Resolved' }, summary: 'Fixed' },
+        },
+      });
+
+      const updatedProposal = await prisma.proposal.findUnique({ where: { id: proposal.id } });
+      expect(updatedProposal!.status).toBe('shipped');
+    });
+
+    it('does not auto-ship if already shipped', async () => {
+      const theme = await createTheme();
+      const proposal = await createProposal(theme.id, { status: 'shipped' });
+      await createJiraIssue(proposal.id, { jiraKey: 'PROJ-80' });
+
+      const result = await jiraService.handleWebhook({
+        issue: {
+          key: 'PROJ-80',
+          fields: { status: { name: 'Done' }, summary: 'Already done' },
+        },
+      });
+
+      expect(result.processed).toBe(true);
+      // Status should remain shipped (no extra update)
+      const updatedProposal = await prisma.proposal.findUnique({ where: { id: proposal.id } });
+      expect(updatedProposal!.status).toBe('shipped');
+    });
+
+    it('ignores untracked issues', async () => {
+      const result = await jiraService.handleWebhook({
+        issue: {
+          key: 'UNKNOWN-1',
+          fields: { status: { name: 'Done' }, summary: 'Not tracked' },
+        },
+      });
+
+      expect(result.processed).toBe(false);
+    });
+
+    it('ignores payloads without issue key', async () => {
+      const result = await jiraService.handleWebhook({});
+      expect(result.processed).toBe(false);
+    });
+  });
+
+  // ─── getDashboardSummary ───────────────────────────────
+
+  describe('getDashboardSummary', () => {
+    it('returns empty summary when nothing exported', async () => {
+      const summary = await jiraService.getDashboardSummary();
+      expect(summary.totalExported).toBe(0);
+      expect(summary.byStatus).toEqual({});
+      expect(summary.recentExports).toEqual([]);
+      expect(summary.epicCount).toBe(0);
+    });
+
+    it('returns correct counts and status breakdown', async () => {
+      const theme = await createTheme();
+      const p1 = await createProposal(theme.id);
+      const p2 = await createProposal(theme.id);
+      const p3 = await createProposal(theme.id);
+      await createJiraIssue(p1.id, { jiraKey: 'PROJ-A', status: 'To Do' });
+      await createJiraIssue(p2.id, { jiraKey: 'PROJ-B', status: 'In Progress' });
+      await createJiraIssue(p3.id, { jiraKey: 'PROJ-C', status: 'To Do' });
+
+      const summary = await jiraService.getDashboardSummary();
+      expect(summary.totalExported).toBe(3);
+      expect(summary.byStatus['To Do']).toBe(2);
+      expect(summary.byStatus['In Progress']).toBe(1);
+      expect(summary.recentExports).toHaveLength(3);
+    });
+
+    it('counts epics from themes', async () => {
+      await createTheme({
+        jiraEpicKey: 'PROJ-EPIC-1',
+        jiraEpicUrl: 'https://test.atlassian.net/browse/PROJ-EPIC-1',
+      });
+      await createTheme({
+        jiraEpicKey: 'PROJ-EPIC-2',
+        jiraEpicUrl: 'https://test.atlassian.net/browse/PROJ-EPIC-2',
+      });
+      await createTheme(); // no epic
+
+      const summary = await jiraService.getDashboardSummary();
+      expect(summary.epicCount).toBe(2);
+    });
+
+    it('limits recent exports to 5', async () => {
+      const theme = await createTheme();
+      for (let i = 0; i < 7; i++) {
+        const p = await createProposal(theme.id);
+        await createJiraIssue(p.id, { jiraKey: `PROJ-${i}` });
+      }
+
+      const summary = await jiraService.getDashboardSummary();
+      expect(summary.totalExported).toBe(7);
+      expect(summary.recentExports).toHaveLength(5);
+    });
+  });
+});

--- a/packages/web/src/components/dashboard/ActivityFeed.tsx
+++ b/packages/web/src/components/dashboard/ActivityFeed.tsx
@@ -1,4 +1,4 @@
-import { Upload, Brain, Lightbulb, FileText } from 'lucide-react';
+import { Upload, Brain, Lightbulb, FileText, Blocks } from 'lucide-react';
 import { formatDate } from '@/lib/utils';
 import type { ActivityEntry } from '@/lib/api';
 
@@ -7,6 +7,7 @@ const TYPE_ICONS: Record<string, React.ReactNode> = {
   synthesis: <Brain size={16} className="text-accent-purple" />,
   proposal_generation: <Lightbulb size={16} className="text-warning" />,
   spec_generation: <FileText size={16} className="text-success" />,
+  jira_export: <Blocks size={16} className="text-accent-blue" />,
 };
 
 export function ActivityFeed({ activities }: { activities: ActivityEntry[] }) {

--- a/packages/web/src/components/dashboard/JiraSyncWidget.tsx
+++ b/packages/web/src/components/dashboard/JiraSyncWidget.tsx
@@ -1,0 +1,134 @@
+import { ExternalLink, RefreshCw, Blocks } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { Button } from '@/components/ui/Button';
+import { useJiraDashboard, useJiraSyncAll } from '@/hooks/useJira';
+
+const STATUS_COLORS: Record<string, string> = {
+  'To Do': 'bg-text-muted/20 text-text-muted',
+  'In Progress': 'bg-accent-blue/20 text-accent-blue',
+  'In Review': 'bg-accent-purple/20 text-accent-purple',
+  Done: 'bg-success/20 text-success',
+  Closed: 'bg-success/20 text-success',
+  Resolved: 'bg-success/20 text-success',
+};
+
+function getStatusColor(status: string): string {
+  return STATUS_COLORS[status] || 'bg-bg-surface-2 text-text-secondary';
+}
+
+export function JiraSyncWidget() {
+  const { data, isLoading } = useJiraDashboard();
+  const syncAllMutation = useJiraSyncAll();
+  const navigate = useNavigate();
+
+  if (isLoading || !data) return null;
+
+  if (data.totalExported === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-6 text-center">
+        <Blocks size={28} className="text-text-muted mb-2" />
+        <p className="text-sm text-text-secondary mb-1">No proposals exported to Jira yet</p>
+        <p className="text-xs text-text-muted mb-3">
+          Export proposals or themes from their detail pages, or configure Jira in Settings.
+        </p>
+        <Button variant="secondary" size="sm" onClick={() => navigate('/settings')}>
+          Configure Jira
+        </Button>
+      </div>
+    );
+  }
+
+  const statusEntries = Object.entries(data.byStatus).sort((a, b) => b[1] - a[1]);
+
+  return (
+    <div className="space-y-4">
+      {/* Summary stats */}
+      <div className="flex items-center gap-4">
+        <div className="text-center">
+          <p className="text-2xl font-bold text-text-primary">{data.totalExported}</p>
+          <p className="text-[10px] text-text-muted uppercase tracking-wider">Exported</p>
+        </div>
+        <div className="text-center">
+          <p className="text-2xl font-bold text-accent-purple">{data.epicCount}</p>
+          <p className="text-[10px] text-text-muted uppercase tracking-wider">Epics</p>
+        </div>
+        <div className="flex-1" />
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => syncAllMutation.mutate()}
+          loading={syncAllMutation.isPending}
+          title="Sync all statuses from Jira"
+        >
+          <RefreshCw size={14} />
+          Sync All
+        </Button>
+      </div>
+
+      {syncAllMutation.data && (
+        <p className="text-xs text-success">
+          Synced {syncAllMutation.data.synced} issues
+          {syncAllMutation.data.autoShipped > 0 &&
+            `, ${syncAllMutation.data.autoShipped} auto-shipped`}
+        </p>
+      )}
+
+      {/* Status breakdown bar */}
+      {statusEntries.length > 0 && (
+        <div>
+          <div className="flex rounded-full overflow-hidden h-2 mb-2">
+            {statusEntries.map(([status, count]) => (
+              <div
+                key={status}
+                className={getStatusColor(status).split(' ')[0]}
+                style={{ width: `${(count / data.totalExported) * 100}%` }}
+                title={`${status}: ${count}`}
+              />
+            ))}
+          </div>
+          <div className="flex flex-wrap gap-x-3 gap-y-1">
+            {statusEntries.map(([status, count]) => (
+              <div key={status} className="flex items-center gap-1.5">
+                <span
+                  className={`inline-block w-2 h-2 rounded-full ${getStatusColor(status).split(' ')[0]}`}
+                />
+                <span className="text-[10px] text-text-muted">
+                  {status} ({count})
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Recent exports */}
+      {data.recentExports.length > 0 && (
+        <div className="space-y-1.5">
+          <p className="text-[10px] text-text-muted uppercase tracking-wider">Recent</p>
+          {data.recentExports.map((issue) => (
+            <div
+              key={issue.jiraKey}
+              className="flex items-center gap-2 px-2 py-1.5 rounded-lg hover:bg-bg-surface-2 transition-colors"
+            >
+              <a
+                href={issue.jiraUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-xs font-mono text-accent-blue hover:underline flex items-center gap-1"
+              >
+                {issue.jiraKey}
+                <ExternalLink size={9} />
+              </a>
+              <span
+                className={`text-[10px] px-1.5 py-0.5 rounded-full ${getStatusColor(issue.status)}`}
+              >
+                {issue.status}
+              </span>
+              <p className="text-xs text-text-secondary truncate flex-1">{issue.summary}</p>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/components/dashboard/OnboardingSteps.tsx
+++ b/packages/web/src/components/dashboard/OnboardingSteps.tsx
@@ -34,7 +34,7 @@ export function OnboardingSteps({
     {
       id: 1,
       title: 'Import Feedback',
-      description: 'Upload a CSV or JSON file, or add feedback manually.',
+      description: 'Upload a CSV or JSON file, import from Jira, or add feedback manually.',
       icon: <Upload size={18} />,
       status: getStatus(feedbackCount, true),
       completedText: step1Complete

--- a/packages/web/src/components/dashboard/QuickActions.tsx
+++ b/packages/web/src/components/dashboard/QuickActions.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from 'react-router-dom';
-import { Upload, Brain, Lightbulb } from 'lucide-react';
+import { Upload, Brain, Lightbulb, Blocks } from 'lucide-react';
 
 export function QuickActions() {
   const navigate = useNavigate();
@@ -7,7 +7,7 @@ export function QuickActions() {
   const actions = [
     {
       label: 'Import Feedback',
-      description: 'Upload CSV or JSON file',
+      description: 'Upload CSV, JSON, or from Jira',
       icon: <Upload size={20} />,
       onClick: () => navigate('/feedback'),
     },
@@ -23,10 +23,16 @@ export function QuickActions() {
       icon: <Lightbulb size={20} />,
       onClick: () => navigate('/proposals'),
     },
+    {
+      label: 'Jira Integration',
+      description: 'Export, sync & import from Jira',
+      icon: <Blocks size={20} />,
+      onClick: () => navigate('/settings'),
+    },
   ];
 
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
       {actions.map((action) => (
         <button
           key={action.label}

--- a/packages/web/src/components/feedback/ImportModal.tsx
+++ b/packages/web/src/components/feedback/ImportModal.tsx
@@ -1,20 +1,24 @@
 import { useState, useCallback } from 'react';
-import { X } from 'lucide-react';
+import { X, Download, CheckCircle2 } from 'lucide-react';
 import { FileDropzone } from './FileDropzone';
 import { ColumnMapper } from './ColumnMapper';
 import { ImportProgress } from './ImportProgress';
 import { Button } from '@/components/ui/Button';
 import { useImportPreview, useImportCSV, useImportJSON } from '@/hooks/useImport';
+import { useJiraImportFeedback } from '@/hooks/useJira';
 
 interface ImportModalProps {
   isOpen: boolean;
   onClose: () => void;
 }
 
+type ImportSource = 'file' | 'jira';
 type Step = 'upload' | 'preview' | 'progress';
 
 export function ImportModal({ isOpen, onClose }: ImportModalProps) {
+  const [importSource, setImportSource] = useState<ImportSource>('file');
   const [step, setStep] = useState<Step>('upload');
+  const [jql, setJql] = useState('');
   const [file, setFile] = useState<File | null>(null);
   const [headers, setHeaders] = useState<string[]>([]);
   const [preview, setPreview] = useState<Record<string, string>[]>([]);
@@ -32,6 +36,7 @@ export function ImportModal({ isOpen, onClose }: ImportModalProps) {
   const previewMutation = useImportPreview();
   const csvMutation = useImportCSV();
   const jsonMutation = useImportJSON();
+  const jiraImportMutation = useJiraImportFeedback();
 
   const handleFile = useCallback(
     async (f: File) => {
@@ -90,7 +95,16 @@ export function ImportModal({ isOpen, onClose }: ImportModalProps) {
     setMapping((prev) => ({ ...prev, [field]: column }));
   }, []);
 
+  const handleJiraImport = useCallback(async () => {
+    try {
+      await jiraImportMutation.mutateAsync(jql.trim() ? { jql: jql.trim() } : undefined);
+    } catch {
+      setError('Jira import failed. Check your Jira configuration in Settings.');
+    }
+  }, [jql, jiraImportMutation]);
+
   const handleClose = useCallback(() => {
+    setImportSource('file');
     setStep('upload');
     setFile(null);
     setHeaders([]);
@@ -100,6 +114,7 @@ export function ImportModal({ isOpen, onClose }: ImportModalProps) {
     setSuggestedMapping({});
     setJobId(null);
     setSyncResult(null);
+    setJql('');
     setError('');
     onClose();
   }, [onClose]);
@@ -108,11 +123,13 @@ export function ImportModal({ isOpen, onClose }: ImportModalProps) {
 
   const isComplete = syncResult || jobId;
   const stepTitle =
-    step === 'upload'
-      ? 'Import Feedback'
-      : step === 'preview'
-        ? 'Import Feedback — Map Columns'
-        : 'Import Feedback — Importing...';
+    importSource === 'jira'
+      ? 'Import from Jira'
+      : step === 'upload'
+        ? 'Import Feedback'
+        : step === 'preview'
+          ? 'Import Feedback — Map Columns'
+          : 'Import Feedback — Importing...';
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
@@ -126,98 +143,171 @@ export function ImportModal({ isOpen, onClose }: ImportModalProps) {
           </button>
         </div>
 
+        {/* Source Toggle */}
+        <div className="flex border-b border-border">
+          <button
+            onClick={() => {
+              setImportSource('file');
+              setError('');
+            }}
+            className={`flex-1 px-4 py-2.5 text-sm font-medium transition-colors ${
+              importSource === 'file'
+                ? 'text-accent-blue border-b-2 border-accent-blue'
+                : 'text-text-muted hover:text-text-secondary'
+            }`}
+          >
+            From File
+          </button>
+          <button
+            onClick={() => {
+              setImportSource('jira');
+              setError('');
+            }}
+            className={`flex-1 px-4 py-2.5 text-sm font-medium transition-colors ${
+              importSource === 'jira'
+                ? 'text-accent-blue border-b-2 border-accent-blue'
+                : 'text-text-muted hover:text-text-secondary'
+            }`}
+          >
+            From Jira
+          </button>
+        </div>
+
         {/* Body */}
         <div className="px-6 py-6">
-          {step === 'upload' && <FileDropzone onFile={handleFile} file={file} error={error} />}
-
-          {step === 'preview' && (
-            <div className="space-y-6">
-              <div className="flex items-center gap-3 text-sm text-text-secondary">
-                <span className="font-medium text-text-primary">{file?.name}</span>
-                <span>({totalRows} rows)</span>
+          {importSource === 'jira' ? (
+            <div className="space-y-4">
+              <p className="text-sm text-text-secondary">
+                Import bugs and stories from your connected Jira project as feedback items for AI
+                analysis.
+              </p>
+              <div>
+                <label className="text-sm font-medium text-text-primary block mb-1.5">
+                  Custom JQL (optional)
+                </label>
+                <input
+                  type="text"
+                  value={jql}
+                  onChange={(e) => setJql(e.target.value)}
+                  placeholder="project = PROJ AND type in (Bug, Story) AND status != Done"
+                  className="w-full bg-bg-surface-2 border border-border rounded-lg px-3 py-2 text-sm text-text-primary placeholder:text-text-muted font-mono"
+                />
+                <p className="text-[10px] text-text-muted mt-1">
+                  Leave empty to use the default query for your configured project.
+                </p>
               </div>
+              <Button onClick={handleJiraImport} loading={jiraImportMutation.isPending}>
+                <Download size={14} />
+                Import from Jira
+              </Button>
+              {jiraImportMutation.data && (
+                <p className="text-sm text-success flex items-center gap-1.5">
+                  <CheckCircle2 size={14} />
+                  Imported {jiraImportMutation.data.imported} items (
+                  {jiraImportMutation.data.skipped} duplicates skipped)
+                </p>
+              )}
+              {error && <p className="text-sm text-danger">{error}</p>}
+            </div>
+          ) : (
+            <>
+              {step === 'upload' && <FileDropzone onFile={handleFile} file={file} error={error} />}
 
-              <ColumnMapper
-                headers={headers}
-                mapping={mapping}
-                suggestedMapping={suggestedMapping}
-                onChange={handleMappingChange}
-              />
-
-              {/* Preview table */}
-              {preview.length > 0 && (
-                <div>
-                  <p className="text-xs text-text-muted font-medium uppercase tracking-wider mb-2">
-                    Preview (first {preview.length} rows)
-                  </p>
-                  <div className="overflow-x-auto border border-border rounded-lg">
-                    <table className="w-full text-xs">
-                      <thead>
-                        <tr className="bg-bg-surface-2 border-b border-border">
-                          {headers.slice(0, 5).map((h) => (
-                            <th key={h} className="px-3 py-2 text-left text-text-muted font-medium">
-                              {h}
-                            </th>
-                          ))}
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {preview.map((row, i) => (
-                          <tr key={i} className="border-b border-border">
-                            {headers.slice(0, 5).map((h) => (
-                              <td
-                                key={h}
-                                className="px-3 py-2 text-text-primary max-w-[200px] truncate"
-                              >
-                                {row[h] || <span className="text-text-muted">(empty)</span>}
-                              </td>
-                            ))}
-                          </tr>
-                        ))}
-                      </tbody>
-                    </table>
+              {step === 'preview' && (
+                <div className="space-y-6">
+                  <div className="flex items-center gap-3 text-sm text-text-secondary">
+                    <span className="font-medium text-text-primary">{file?.name}</span>
+                    <span>({totalRows} rows)</span>
                   </div>
+
+                  <ColumnMapper
+                    headers={headers}
+                    mapping={mapping}
+                    suggestedMapping={suggestedMapping}
+                    onChange={handleMappingChange}
+                  />
+
+                  {/* Preview table */}
+                  {preview.length > 0 && (
+                    <div>
+                      <p className="text-xs text-text-muted font-medium uppercase tracking-wider mb-2">
+                        Preview (first {preview.length} rows)
+                      </p>
+                      <div className="overflow-x-auto border border-border rounded-lg">
+                        <table className="w-full text-xs">
+                          <thead>
+                            <tr className="bg-bg-surface-2 border-b border-border">
+                              {headers.slice(0, 5).map((h) => (
+                                <th
+                                  key={h}
+                                  className="px-3 py-2 text-left text-text-muted font-medium"
+                                >
+                                  {h}
+                                </th>
+                              ))}
+                            </tr>
+                          </thead>
+                          <tbody>
+                            {preview.map((row, i) => (
+                              <tr key={i} className="border-b border-border">
+                                {headers.slice(0, 5).map((h) => (
+                                  <td
+                                    key={h}
+                                    className="px-3 py-2 text-text-primary max-w-[200px] truncate"
+                                  >
+                                    {row[h] || <span className="text-text-muted">(empty)</span>}
+                                  </td>
+                                ))}
+                              </tr>
+                            ))}
+                          </tbody>
+                        </table>
+                      </div>
+                    </div>
+                  )}
                 </div>
               )}
-            </div>
+
+              {step === 'progress' && <ImportProgress jobId={jobId} syncResult={syncResult} />}
+            </>
           )}
-
-          {step === 'progress' && <ImportProgress jobId={jobId} syncResult={syncResult} />}
         </div>
 
-        {/* Footer */}
-        <div className="flex items-center justify-between px-6 py-4 border-t border-border">
-          <div>
-            {step === 'preview' && (
-              <Button
-                variant="ghost"
-                onClick={() => {
-                  setStep('upload');
-                  setFile(null);
-                }}
-              >
-                Back
-              </Button>
-            )}
+        {/* Footer — only for file import */}
+        {importSource === 'file' && (
+          <div className="flex items-center justify-between px-6 py-4 border-t border-border">
+            <div>
+              {step === 'preview' && (
+                <Button
+                  variant="ghost"
+                  onClick={() => {
+                    setStep('upload');
+                    setFile(null);
+                  }}
+                >
+                  Back
+                </Button>
+              )}
+            </div>
+            <div className="flex items-center gap-3">
+              {step !== 'progress' && (
+                <Button variant="secondary" onClick={handleClose}>
+                  Cancel
+                </Button>
+              )}
+              {step === 'preview' && (
+                <Button
+                  onClick={handleImport}
+                  disabled={!mapping.content}
+                  loading={csvMutation.isPending || jsonMutation.isPending}
+                >
+                  Import {totalRows} rows
+                </Button>
+              )}
+              {step === 'progress' && isComplete && <Button onClick={handleClose}>Done</Button>}
+            </div>
           </div>
-          <div className="flex items-center gap-3">
-            {step !== 'progress' && (
-              <Button variant="secondary" onClick={handleClose}>
-                Cancel
-              </Button>
-            )}
-            {step === 'preview' && (
-              <Button
-                onClick={handleImport}
-                disabled={!mapping.content}
-                loading={csvMutation.isPending || jsonMutation.isPending}
-              >
-                Import {totalRows} rows
-              </Button>
-            )}
-            {step === 'progress' && isComplete && <Button onClick={handleClose}>Done</Button>}
-          </div>
-        </div>
+        )}
       </div>
     </div>
   );

--- a/packages/web/src/components/proposals/ProposalDetail.tsx
+++ b/packages/web/src/components/proposals/ProposalDetail.tsx
@@ -1,10 +1,28 @@
-import { X, Check, XCircle, Rocket, RotateCcw, FileText } from 'lucide-react';
+import {
+  X,
+  Check,
+  XCircle,
+  Rocket,
+  RotateCcw,
+  FileText,
+  ExternalLink,
+  RefreshCw,
+  Unlink,
+  Paperclip,
+} from 'lucide-react';
 import { StatusBadge } from './StatusBadge';
 import { RICEScoreDisplay } from './RICEScoreDisplay';
 import { Button } from '@/components/ui/Button';
 import { Skeleton } from '@/components/ui/Skeleton';
 import { useProposalDetail, useUpdateProposal, useDeleteProposal } from '@/hooks/useProposals';
 import { useGenerateSpec, useSpecByProposal } from '@/hooks/useSpecs';
+import {
+  useJiraExport,
+  useJiraIssueByProposal,
+  useJiraSyncStatus,
+  useJiraUnlink,
+  useJiraAttachSpec,
+} from '@/hooks/useJira';
 import { getSentimentColor, getUrgencyColor } from '@/lib/utils';
 
 interface ProposalDetailProps {
@@ -39,6 +57,11 @@ export function ProposalDetail({ proposalId, onClose }: ProposalDetailProps) {
   const deleteMutation = useDeleteProposal();
   const generateSpecMutation = useGenerateSpec();
   const { data: existingSpec } = useSpecByProposal(proposalId);
+  const jiraExportMutation = useJiraExport();
+  const jiraSyncMutation = useJiraSyncStatus();
+  const jiraUnlinkMutation = useJiraUnlink();
+  const jiraAttachSpecMutation = useJiraAttachSpec();
+  const { data: jiraIssue } = useJiraIssueByProposal(proposalId);
 
   if (isLoading) {
     return (
@@ -112,6 +135,88 @@ export function ProposalDetail({ proposalId, onClose }: ProposalDetailProps) {
                 <FileText size={14} />
                 Generate Spec
               </Button>
+            )}
+          </div>
+        )}
+
+        {/* Jira Integration */}
+        {(proposal.status === 'approved' || proposal.status === 'shipped') && (
+          <div>
+            {jiraIssue ? (
+              <div className="bg-bg-surface-2 rounded-lg p-3">
+                <div className="flex items-center justify-between mb-1">
+                  <div className="flex items-center gap-2">
+                    <a
+                      href={jiraIssue.jiraUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-sm font-mono text-accent-blue hover:underline flex items-center gap-1"
+                    >
+                      {jiraIssue.jiraKey}
+                      <ExternalLink size={10} />
+                    </a>
+                    <span className="text-[10px] px-1.5 py-0.5 rounded bg-bg-surface border border-border text-text-muted">
+                      {jiraIssue.status}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-1">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => jiraSyncMutation.mutate(proposal.id)}
+                      loading={jiraSyncMutation.isPending}
+                      title="Sync status from Jira"
+                    >
+                      <RefreshCw size={12} />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => {
+                        if (
+                          confirm('Unlink this Jira issue? The issue in Jira will not be deleted.')
+                        ) {
+                          jiraUnlinkMutation.mutate(proposal.id);
+                        }
+                      }}
+                      loading={jiraUnlinkMutation.isPending}
+                      title="Unlink Jira issue"
+                    >
+                      <Unlink size={12} className="text-danger" />
+                    </Button>
+                  </div>
+                </div>
+                <p className="text-xs text-text-muted">Linked to Jira</p>
+                {existingSpec && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="mt-2"
+                    onClick={() => jiraAttachSpecMutation.mutate(proposal.id)}
+                    loading={jiraAttachSpecMutation.isPending}
+                    title="Attach PRD spec as a Jira comment"
+                  >
+                    <Paperclip size={12} />
+                    <span className="text-xs">
+                      {jiraAttachSpecMutation.isSuccess ? 'Spec Attached!' : 'Attach Spec to Jira'}
+                    </span>
+                  </Button>
+                )}
+              </div>
+            ) : (
+              <Button
+                variant="secondary"
+                size="sm"
+                loading={jiraExportMutation.isPending}
+                onClick={() => jiraExportMutation.mutate(proposal.id)}
+              >
+                Export to Jira
+              </Button>
+            )}
+            {jiraExportMutation.isError && (
+              <p className="text-xs text-danger mt-1">
+                {(jiraExportMutation.error as Error)?.message || 'Failed to export'}
+              </p>
             )}
           </div>
         )}

--- a/packages/web/src/components/settings/JiraConfigSection.tsx
+++ b/packages/web/src/components/settings/JiraConfigSection.tsx
@@ -1,0 +1,391 @@
+import { useState } from 'react';
+import {
+  CheckCircle2,
+  XCircle,
+  Eye,
+  EyeOff,
+  RefreshCw,
+  ExternalLink,
+  Download,
+  Copy,
+  Check,
+} from 'lucide-react';
+import { Button } from '@/components/ui/Button';
+import {
+  useJiraTestConnection,
+  useJiraSaveConfig,
+  useJiraProjects,
+  useJiraIssueTypes,
+  useJiraIssues,
+  useJiraImportFeedback,
+  useJiraSyncAll,
+} from '@/hooks/useJira';
+
+interface JiraConfigSectionProps {
+  settings: Record<string, string>;
+  onUpdate: (key: string, value: string) => void;
+}
+
+export function JiraConfigSection({ settings, onUpdate }: JiraConfigSectionProps) {
+  const [host, setHost] = useState(settings['jira_host'] || '');
+  const [email, setEmail] = useState(settings['jira_email'] || '');
+  const [apiToken, setApiToken] = useState('');
+  const [showToken, setShowToken] = useState(false);
+  const [projectKey, setProjectKey] = useState(settings['jira_project_key'] || '');
+  const [issueType, setIssueType] = useState(settings['jira_issue_type'] || 'Story');
+
+  const [jql, setJql] = useState('');
+  const [copiedWebhook, setCopiedWebhook] = useState(false);
+
+  const testMutation = useJiraTestConnection();
+  const saveMutation = useJiraSaveConfig();
+  const projectsQuery = useJiraProjects();
+  const issueTypesQuery = useJiraIssueTypes();
+  const { data: jiraIssues } = useJiraIssues();
+  const importMutation = useJiraImportFeedback();
+  const syncAllMutation = useJiraSyncAll();
+
+  const hasToken = (settings['jira_api_token'] || '').length > 0;
+  const isConfigured = hasToken && host && email;
+  const webhookUrl = `${window.location.origin}/api/jira/webhook`;
+
+  const handleSave = () => {
+    const config: Record<string, string> = {};
+    if (host.trim()) config['jira_host'] = host.trim();
+    if (email.trim()) config['jira_email'] = email.trim();
+    if (apiToken.trim()) config['jira_api_token'] = apiToken.trim();
+    if (projectKey.trim()) config['jira_project_key'] = projectKey.trim();
+    if (issueType.trim()) config['jira_issue_type'] = issueType.trim();
+
+    saveMutation.mutate(config, {
+      onSuccess: () => {
+        setApiToken('');
+        // Re-fetch settings to reflect saved values
+        Object.entries(config).forEach(([k, v]) => {
+          if (k !== 'jira_api_token') onUpdate(k, v);
+        });
+      },
+    });
+  };
+
+  const handleLoadProjects = () => {
+    projectsQuery.refetch();
+  };
+
+  const handleLoadIssueTypes = () => {
+    issueTypesQuery.refetch();
+  };
+
+  const handleImport = () => {
+    importMutation.mutate(jql.trim() ? { jql: jql.trim() } : undefined);
+  };
+
+  const handleCopyWebhook = () => {
+    navigator.clipboard.writeText(webhookUrl);
+    setCopiedWebhook(true);
+    setTimeout(() => setCopiedWebhook(false), 2000);
+  };
+
+  return (
+    <div className="space-y-5">
+      {/* Connection Settings */}
+      <div>
+        <label className="text-sm font-medium text-text-primary block mb-1.5">
+          Jira Instance URL
+        </label>
+        <input
+          type="url"
+          value={host}
+          onChange={(e) => setHost(e.target.value)}
+          placeholder="https://your-org.atlassian.net"
+          className="w-full bg-bg-surface-2 border border-border rounded-lg px-3 py-2 text-sm text-text-primary placeholder:text-text-muted"
+        />
+      </div>
+
+      <div>
+        <label className="text-sm font-medium text-text-primary block mb-1.5">Jira Email</label>
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="you@company.com"
+          className="w-full bg-bg-surface-2 border border-border rounded-lg px-3 py-2 text-sm text-text-primary placeholder:text-text-muted"
+        />
+      </div>
+
+      <div>
+        <label className="text-sm font-medium text-text-primary block mb-1.5">API Token</label>
+        {hasToken && (
+          <p className="text-xs text-text-muted mb-2">
+            Token saved. Enter a new one to replace it.
+          </p>
+        )}
+        <div className="relative">
+          <input
+            type={showToken ? 'text' : 'password'}
+            value={apiToken}
+            onChange={(e) => setApiToken(e.target.value)}
+            placeholder={hasToken ? 'Enter new token to replace...' : 'Paste your Jira API token'}
+            className="w-full bg-bg-surface-2 border border-border rounded-lg px-3 py-2 text-sm text-text-primary placeholder:text-text-muted pr-10"
+          />
+          <button
+            type="button"
+            onClick={() => setShowToken(!showToken)}
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-text-muted hover:text-text-secondary"
+          >
+            {showToken ? <EyeOff size={14} /> : <Eye size={14} />}
+          </button>
+        </div>
+        <p className="text-[10px] text-text-muted mt-1">
+          Generate at{' '}
+          <a
+            href="https://id.atlassian.com/manage-profile/security/api-tokens"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-accent-blue hover:underline"
+          >
+            Atlassian API Tokens
+            <ExternalLink size={10} className="inline ml-0.5" />
+          </a>
+        </p>
+      </div>
+
+      {/* Project & Issue Type */}
+      <div className="pt-4 border-t border-border">
+        <div className="flex items-end gap-2 mb-4">
+          <div className="flex-1">
+            <label className="text-sm font-medium text-text-primary block mb-1.5">
+              Project Key
+            </label>
+            {projectsQuery.data && projectsQuery.data.length > 0 ? (
+              <select
+                value={projectKey}
+                onChange={(e) => setProjectKey(e.target.value)}
+                className="w-full bg-bg-surface-2 border border-border rounded-lg px-3 py-2 text-sm text-text-primary"
+              >
+                <option value="">Select a project...</option>
+                {projectsQuery.data.map((p) => (
+                  <option key={p.key} value={p.key}>
+                    {p.key} — {p.name}
+                  </option>
+                ))}
+              </select>
+            ) : (
+              <input
+                type="text"
+                value={projectKey}
+                onChange={(e) => setProjectKey(e.target.value.toUpperCase())}
+                placeholder="e.g. PROJ"
+                className="w-full bg-bg-surface-2 border border-border rounded-lg px-3 py-2 text-sm text-text-primary placeholder:text-text-muted"
+              />
+            )}
+          </div>
+          {isConfigured && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleLoadProjects}
+              loading={projectsQuery.isFetching}
+            >
+              <RefreshCw size={14} />
+            </Button>
+          )}
+        </div>
+
+        <div className="flex items-end gap-2">
+          <div className="flex-1">
+            <label className="text-sm font-medium text-text-primary block mb-1.5">
+              Default Issue Type
+            </label>
+            <select
+              value={issueType}
+              onChange={(e) => setIssueType(e.target.value)}
+              className="w-full bg-bg-surface-2 border border-border rounded-lg px-3 py-2 text-sm text-text-primary"
+            >
+              {issueTypesQuery.data && issueTypesQuery.data.length > 0
+                ? issueTypesQuery.data.map((t) => (
+                    <option key={t.id} value={t.name}>
+                      {t.name}
+                    </option>
+                  ))
+                : ['Story', 'Bug', 'Task', 'Epic', 'Sub-task'].map((name) => (
+                    <option key={name} value={name}>
+                      {name}
+                    </option>
+                  ))}
+            </select>
+          </div>
+          {isConfigured && projectKey && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleLoadIssueTypes}
+              loading={issueTypesQuery.isFetching}
+            >
+              <RefreshCw size={14} />
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {/* Actions */}
+      <div className="flex items-center gap-2 pt-4 border-t border-border">
+        <Button size="sm" onClick={handleSave} loading={saveMutation.isPending}>
+          Save Configuration
+        </Button>
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={() => testMutation.mutate()}
+          loading={testMutation.isPending}
+          disabled={!isConfigured}
+        >
+          Test Connection
+        </Button>
+      </div>
+
+      {saveMutation.isSuccess && (
+        <p className="text-xs text-success flex items-center gap-1">
+          <CheckCircle2 size={12} /> Configuration saved.
+        </p>
+      )}
+
+      {testMutation.data && (
+        <div
+          className={`flex items-center gap-2 text-sm ${
+            testMutation.data.success ? 'text-success' : 'text-danger'
+          }`}
+        >
+          {testMutation.data.success ? <CheckCircle2 size={14} /> : <XCircle size={14} />}
+          {testMutation.data.message}
+        </div>
+      )}
+
+      {/* Exported Issues Overview */}
+      {jiraIssues && jiraIssues.length > 0 && (
+        <div className="pt-4 border-t border-border">
+          <h4 className="text-sm font-medium text-text-primary mb-2">
+            Exported Issues ({jiraIssues.length})
+          </h4>
+          <div className="space-y-2 max-h-60 overflow-y-auto">
+            {jiraIssues.map((issue) => (
+              <div
+                key={issue.id}
+                className="flex items-center justify-between bg-bg-surface-2 rounded-lg px-3 py-2"
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <a
+                      href={issue.jiraUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-sm font-mono text-accent-blue hover:underline"
+                    >
+                      {issue.jiraKey}
+                    </a>
+                    <span className="text-[10px] px-1.5 py-0.5 rounded bg-bg-surface border border-border text-text-muted">
+                      {issue.status}
+                    </span>
+                  </div>
+                  <p className="text-xs text-text-secondary truncate">{issue.summary}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Import Feedback from Jira */}
+      {isConfigured && projectKey && (
+        <div className="pt-4 border-t border-border">
+          <h4 className="text-sm font-medium text-text-primary mb-1">Import Feedback from Jira</h4>
+          <p className="text-[10px] text-text-muted mb-3">
+            Pull bugs and stories from your Jira project into ShipScope as feedback items for AI
+            analysis.
+          </p>
+          <div className="mb-2">
+            <label className="text-xs text-text-secondary block mb-1">Custom JQL (optional)</label>
+            <input
+              type="text"
+              value={jql}
+              onChange={(e) => setJql(e.target.value)}
+              placeholder={`project = ${projectKey} AND type in (Bug, Story) AND status != Done`}
+              className="w-full bg-bg-surface-2 border border-border rounded-lg px-3 py-2 text-xs text-text-primary placeholder:text-text-muted font-mono"
+            />
+          </div>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={handleImport}
+            loading={importMutation.isPending}
+          >
+            <Download size={14} />
+            Import from Jira
+          </Button>
+          {importMutation.data && (
+            <p className="text-xs text-success mt-2 flex items-center gap-1">
+              <CheckCircle2 size={12} />
+              Imported {importMutation.data.imported} items ({importMutation.data.skipped}{' '}
+              duplicates skipped)
+            </p>
+          )}
+          {importMutation.isError && (
+            <p className="text-xs text-danger mt-2">
+              Import failed. Check your JQL query and Jira credentials.
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Bulk Sync */}
+      {jiraIssues && jiraIssues.length > 0 && (
+        <div className="pt-4 border-t border-border">
+          <h4 className="text-sm font-medium text-text-primary mb-1">Status Sync</h4>
+          <p className="text-[10px] text-text-muted mb-3">
+            Sync all exported Jira issue statuses back to ShipScope. Proposals are auto-marked as
+            &ldquo;shipped&rdquo; when their Jira issue reaches Done/Closed/Resolved.
+          </p>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => syncAllMutation.mutate()}
+            loading={syncAllMutation.isPending}
+          >
+            <RefreshCw size={14} />
+            Sync All Statuses
+          </Button>
+          {syncAllMutation.data && (
+            <p className="text-xs text-success mt-2 flex items-center gap-1">
+              <CheckCircle2 size={12} />
+              {syncAllMutation.data.synced} synced
+              {syncAllMutation.data.autoShipped > 0 &&
+                `, ${syncAllMutation.data.autoShipped} auto-shipped`}
+              {syncAllMutation.data.errors > 0 && `, ${syncAllMutation.data.errors} errors`}
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Webhook URL */}
+      {isConfigured && (
+        <div className="pt-4 border-t border-border">
+          <h4 className="text-sm font-medium text-text-primary mb-1">
+            Jira Webhook (Real-time Sync)
+          </h4>
+          <p className="text-[10px] text-text-muted mb-3">
+            Add this URL as a webhook in Jira (Settings → System → Webhooks) to enable real-time
+            status sync whenever an issue is updated.
+          </p>
+          <div className="flex items-center gap-2">
+            <code className="flex-1 text-xs bg-bg-surface-2 border border-border rounded-lg px-3 py-2 font-mono text-text-secondary truncate">
+              {webhookUrl}
+            </code>
+            <Button variant="ghost" size="sm" onClick={handleCopyWebhook}>
+              {copiedWebhook ? <Check size={14} className="text-success" /> : <Copy size={14} />}
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/components/themes/ThemeCard.tsx
+++ b/packages/web/src/components/themes/ThemeCard.tsx
@@ -33,11 +33,14 @@ export function ThemeCard({ theme, onClick }: ThemeCardProps) {
     <Card hover onClick={onClick}>
       <div className="flex items-start justify-between gap-3 mb-3">
         <h3 className="text-sm font-medium text-text-primary leading-tight">{theme.name}</h3>
-        {theme.category && (
-          <Badge variant={categoryVariants[theme.category] || 'gray'}>
-            {categoryLabels[theme.category] || theme.category}
-          </Badge>
-        )}
+        <div className="flex items-center gap-1.5 flex-shrink-0">
+          {theme.jiraEpicKey && <Badge variant="blue">Epic</Badge>}
+          {theme.category && (
+            <Badge variant={categoryVariants[theme.category] || 'gray'}>
+              {categoryLabels[theme.category] || theme.category}
+            </Badge>
+          )}
+        </div>
       </div>
 
       <p className="text-xs text-text-secondary line-clamp-2 mb-4">{theme.description}</p>

--- a/packages/web/src/components/themes/ThemeDetail.tsx
+++ b/packages/web/src/components/themes/ThemeDetail.tsx
@@ -1,9 +1,10 @@
-import { X } from 'lucide-react';
+import { X, ExternalLink } from 'lucide-react';
 import { Badge } from '@/components/ui/Badge';
 import { Button } from '@/components/ui/Button';
 import { Skeleton } from '@/components/ui/Skeleton';
 import { getSentimentColor, getUrgencyColor } from '@/lib/utils';
 import { useThemeDetail } from '@/hooks/useThemes';
+import { useJiraExportTheme } from '@/hooks/useJira';
 
 interface ThemeDetailProps {
   themeId: string;
@@ -32,6 +33,7 @@ const categoryVariants: Record<string, 'blue' | 'green' | 'yellow' | 'red' | 'gr
 
 export function ThemeDetail({ themeId, onClose }: ThemeDetailProps) {
   const { data: theme, isLoading } = useThemeDetail(themeId);
+  const epicExportMutation = useJiraExportTheme();
 
   if (isLoading) {
     return (
@@ -108,6 +110,49 @@ export function ThemeDetail({ themeId, onClose }: ThemeDetailProps) {
             </ul>
           </div>
         )}
+
+        {/* Jira Epic Export */}
+        <div>
+          <h4 className="text-xs font-medium text-text-muted uppercase tracking-wider mb-2">
+            Jira Integration
+          </h4>
+          {theme.jiraEpicKey ? (
+            <div className="bg-bg-surface-2 rounded-lg p-3">
+              <div className="flex items-center gap-2">
+                <span className="text-xs text-text-muted">Linked as Epic:</span>
+                <a
+                  href={theme.jiraEpicUrl || '#'}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-sm font-mono text-accent-blue hover:underline flex items-center gap-1"
+                >
+                  {theme.jiraEpicKey}
+                  <ExternalLink size={10} />
+                </a>
+              </div>
+            </div>
+          ) : (
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => epicExportMutation.mutate(themeId)}
+              loading={epicExportMutation.isPending}
+            >
+              Export as Jira Epic
+            </Button>
+          )}
+          {epicExportMutation.isSuccess && epicExportMutation.data && (
+            <p className="text-xs text-success mt-2">
+              Created Epic {epicExportMutation.data.epicKey} with{' '}
+              {epicExportMutation.data.storiesCreated} stories
+            </p>
+          )}
+          {epicExportMutation.isError && (
+            <p className="text-xs text-danger mt-2">
+              Export failed. Check your Jira configuration in Settings.
+            </p>
+          )}
+        </div>
 
         {/* Linked Feedback */}
         {theme.feedbackItems && theme.feedbackItems.length > 0 && (

--- a/packages/web/src/hooks/useJira.ts
+++ b/packages/web/src/hooks/useJira.ts
@@ -1,0 +1,130 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { jiraApi } from '@/lib/api';
+
+export function useJiraTestConnection() {
+  return useMutation({
+    mutationFn: () => jiraApi.testConnection(),
+  });
+}
+
+export function useJiraSaveConfig() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (config: Record<string, string>) => jiraApi.saveConfig(config),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['settings'] });
+    },
+  });
+}
+
+export function useJiraProjects() {
+  return useQuery({
+    queryKey: ['jira', 'projects'],
+    queryFn: () => jiraApi.listProjects(),
+    enabled: false,
+    retry: false,
+  });
+}
+
+export function useJiraIssueTypes() {
+  return useQuery({
+    queryKey: ['jira', 'issue-types'],
+    queryFn: () => jiraApi.listIssueTypes(),
+    enabled: false,
+    retry: false,
+  });
+}
+
+export function useJiraExport() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (proposalId: string) => jiraApi.exportProposal(proposalId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['jira'] });
+    },
+  });
+}
+
+export function useJiraExportTheme() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (themeId: string) => jiraApi.exportTheme(themeId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['jira'] });
+      queryClient.invalidateQueries({ queryKey: ['themes'] });
+    },
+  });
+}
+
+export function useJiraAttachSpec() {
+  return useMutation({
+    mutationFn: (proposalId: string) => jiraApi.attachSpec(proposalId),
+  });
+}
+
+export function useJiraImportFeedback() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (options?: { jql?: string; maxResults?: number }) =>
+      jiraApi.importFeedback(options),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['feedback'] });
+      queryClient.invalidateQueries({ queryKey: ['dashboard'] });
+    },
+  });
+}
+
+export function useJiraSyncStatus() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (proposalId: string) => jiraApi.syncStatus(proposalId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['jira'] });
+    },
+  });
+}
+
+export function useJiraSyncAll() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => jiraApi.syncAll(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['jira'] });
+      queryClient.invalidateQueries({ queryKey: ['proposals'] });
+    },
+  });
+}
+
+export function useJiraIssues() {
+  return useQuery({
+    queryKey: ['jira', 'issues'],
+    queryFn: () => jiraApi.listIssues(),
+    staleTime: 60_000,
+  });
+}
+
+export function useJiraIssueByProposal(proposalId: string) {
+  return useQuery({
+    queryKey: ['jira', 'issue', proposalId],
+    queryFn: () => jiraApi.getByProposal(proposalId),
+    staleTime: 60_000,
+  });
+}
+
+export function useJiraUnlink() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (proposalId: string) => jiraApi.unlink(proposalId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['jira'] });
+    },
+  });
+}
+
+export function useJiraDashboard() {
+  return useQuery({
+    queryKey: ['jira', 'dashboard'],
+    queryFn: () => jiraApi.dashboardSummary(),
+    staleTime: 60_000,
+  });
+}

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -168,6 +168,8 @@ export interface ThemeItem {
   avgSentiment: number;
   avgUrgency: number;
   opportunityScore: number;
+  jiraEpicKey: string | null;
+  jiraEpicUrl: string | null;
   createdAt: string;
   updatedAt: string;
   feedbackItems: {
@@ -439,4 +441,137 @@ export const settingsApi = {
       .then((r) => r.data),
 
   revokeApiKey: (id: string) => api.delete(`/settings/api-keys/${id}`),
+};
+
+// ============================================
+// Jira Integration API
+// ============================================
+
+export interface JiraTestResult {
+  success: boolean;
+  message: string;
+  serverTitle?: string;
+}
+
+export interface JiraProject {
+  id: string;
+  key: string;
+  name: string;
+}
+
+export interface JiraIssueType {
+  id: string;
+  name: string;
+  subtask: boolean;
+}
+
+export interface JiraExportResult {
+  id: string;
+  jiraKey: string;
+  jiraUrl: string;
+}
+
+export interface JiraThemeExportResult {
+  epicKey: string;
+  epicUrl: string;
+  storiesCreated: number;
+  storiesSkipped: number;
+}
+
+export interface JiraImportResult {
+  imported: number;
+  skipped: number;
+  sourceId: string;
+}
+
+export interface JiraSyncAllResult {
+  synced: number;
+  autoShipped: number;
+  errors: number;
+}
+
+export interface JiraDashboardSummary {
+  totalExported: number;
+  byStatus: Record<string, number>;
+  recentExports: {
+    jiraKey: string;
+    summary: string;
+    status: string;
+    jiraUrl: string;
+    createdAt: string;
+  }[];
+  epicCount: number;
+}
+
+export interface JiraIssueItem {
+  id: string;
+  proposalId: string;
+  jiraKey: string;
+  jiraId: string;
+  jiraUrl: string;
+  issueType: string;
+  status: string;
+  summary: string;
+  syncedAt: string;
+  createdAt: string;
+  proposal: {
+    id: string;
+    title: string;
+    status: string;
+    riceScore: number | null;
+  };
+}
+
+export const jiraApi = {
+  // Configuration
+  saveConfig: (config: Record<string, string>) =>
+    api.put<{ data: { saved: boolean } }>('/jira/config', config).then((r) => r.data.data),
+
+  testConnection: () => api.post<{ data: JiraTestResult }>('/jira/test').then((r) => r.data.data),
+
+  listProjects: () => api.get<{ data: JiraProject[] }>('/jira/projects').then((r) => r.data.data),
+
+  listIssueTypes: () =>
+    api.get<{ data: JiraIssueType[] }>('/jira/issue-types').then((r) => r.data.data),
+
+  // Export & Sync
+  exportProposal: (proposalId: string) =>
+    api.post<{ data: JiraExportResult }>(`/jira/export/${proposalId}`).then((r) => r.data.data),
+
+  syncStatus: (proposalId: string) =>
+    api
+      .post<{ data: { jiraKey: string; status: string } }>(`/jira/sync/${proposalId}`)
+      .then((r) => r.data.data),
+
+  listIssues: () => api.get<{ data: JiraIssueItem[] }>('/jira/issues').then((r) => r.data.data),
+
+  getByProposal: (proposalId: string) =>
+    api.get<{ data: JiraIssueItem | null }>(`/jira/issues/${proposalId}`).then((r) => r.data.data),
+
+  unlink: (proposalId: string) => api.delete(`/jira/issues/${proposalId}`),
+
+  // Theme → Epic bulk export
+  exportTheme: (themeId: string) =>
+    api
+      .post<{ data: JiraThemeExportResult }>(`/jira/export-theme/${themeId}`)
+      .then((r) => r.data.data),
+
+  // Spec attachment
+  attachSpec: (proposalId: string) =>
+    api
+      .post<{ data: { jiraKey: string; commented: boolean } }>(`/jira/attach-spec/${proposalId}`)
+      .then((r) => r.data.data),
+
+  // Import from Jira
+  importFeedback: (options?: { jql?: string; maxResults?: number }) =>
+    api
+      .post<{ data: JiraImportResult }>('/jira/import-feedback', options || {})
+      .then((r) => r.data.data),
+
+  // Bulk sync
+  syncAll: () => api.post<{ data: JiraSyncAllResult }>('/jira/sync-all').then((r) => r.data.data),
+
+  // Dashboard
+  dashboardSummary: () =>
+    api.get<{ data: JiraDashboardSummary }>('/jira/dashboard').then((r) => r.data.data),
 };

--- a/packages/web/src/pages/DashboardPage.tsx
+++ b/packages/web/src/pages/DashboardPage.tsx
@@ -9,6 +9,7 @@ import { SentimentGauge } from '@/components/dashboard/SentimentGauge';
 import { QuickActions } from '@/components/dashboard/QuickActions';
 import { DashboardEmptyState } from '@/components/dashboard/DashboardEmptyState';
 import { OnboardingSteps } from '@/components/dashboard/OnboardingSteps';
+import { JiraSyncWidget } from '@/components/dashboard/JiraSyncWidget';
 import {
   useDashboardStats,
   useActivityFeed,
@@ -116,6 +117,14 @@ export default function DashboardPage() {
                 </h3>
                 <QuickActions />
               </div>
+            </div>
+
+            {/* Jira Integration Widget */}
+            <div className="bg-bg-surface border border-border rounded-xl p-5">
+              <h3 className="text-sm font-medium text-text-muted uppercase tracking-wider mb-4">
+                Jira Integration
+              </h3>
+              <JiraSyncWidget />
             </div>
 
             {/* Onboarding banner when some steps incomplete */}

--- a/packages/web/src/pages/SettingsPage.tsx
+++ b/packages/web/src/pages/SettingsPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Bot, Sliders, Database, Webhook, Info } from 'lucide-react';
+import { Bot, Sliders, Database, Webhook, Info, Blocks } from 'lucide-react';
 import { Topbar } from '@/components/layout/Topbar';
 import { PageContainer } from '@/components/layout/PageContainer';
 import { Skeleton } from '@/components/ui/Skeleton';
@@ -7,14 +7,16 @@ import { AIConfigSection } from '@/components/settings/AIConfigSection';
 import { SynthesisSettingsSection } from '@/components/settings/SynthesisSettingsSection';
 import { DataManagementSection } from '@/components/settings/DataManagementSection';
 import { WebhookSection } from '@/components/settings/WebhookSection';
+import { JiraConfigSection } from '@/components/settings/JiraConfigSection';
 import { AboutSection } from '@/components/settings/AboutSection';
 import { useSettings, useUpdateSettings } from '@/hooks/useSettings';
 
-type Section = 'ai' | 'synthesis' | 'data' | 'webhook' | 'about';
+type Section = 'ai' | 'synthesis' | 'jira' | 'data' | 'webhook' | 'about';
 
 const SECTIONS: { id: Section; label: string; icon: React.ReactNode }[] = [
   { id: 'ai', label: 'AI Configuration', icon: <Bot size={16} /> },
   { id: 'synthesis', label: 'Synthesis Settings', icon: <Sliders size={16} /> },
+  { id: 'jira', label: 'Jira Integration', icon: <Blocks size={16} /> },
   { id: 'data', label: 'Data Management', icon: <Database size={16} /> },
   { id: 'webhook', label: 'Webhooks & API Keys', icon: <Webhook size={16} /> },
   { id: 'about', label: 'About', icon: <Info size={16} /> },
@@ -63,6 +65,7 @@ export default function SettingsPage() {
               <p className="text-xs text-text-muted mb-6">
                 {activeSection === 'ai' && 'Configure your OpenAI API key and model preferences.'}
                 {activeSection === 'synthesis' && 'Tune the feedback clustering parameters.'}
+                {activeSection === 'jira' && 'Connect to Jira to export proposals as issues.'}
                 {activeSection === 'data' && 'Export or delete all application data.'}
                 {activeSection === 'webhook' && 'Manage webhook URL and API key authentication.'}
                 {activeSection === 'about' && 'Application version and links.'}
@@ -81,6 +84,9 @@ export default function SettingsPage() {
                   )}
                   {activeSection === 'synthesis' && (
                     <SynthesisSettingsSection settings={settings ?? {}} onUpdate={handleUpdate} />
+                  )}
+                  {activeSection === 'jira' && (
+                    <JiraConfigSection settings={settings ?? {}} onUpdate={handleUpdate} />
                   )}
                   {activeSection === 'data' && <DataManagementSection />}
                   {activeSection === 'webhook' && <WebhookSection />}


### PR DESCRIPTION
Closes #25 

## Summary

Adds a full Jira integration enabling bi-directional workflow between ShipScope's feedback analysis pipeline and Jira's project management. Teams can now export proposals/epics to Jira, import Jira issues as feedback, and keep statuses in sync automatically.

## Changes

### Backend (`packages/api`)

**New files:**
- `src/services/jira.service.ts` — 14 service methods (export, import, sync, webhooks, dashboard)
- `src/routes/jira.ts` — 15 REST endpoints under `/api/jira/*`
- `src/schemas/jira.schema.ts` — Zod validation for config and export payloads
- `prisma/migrations/20260314000000_add_jira_integration/migration.sql` — New table and columns

**Modified files:**
- `prisma/schema.prisma` — Added `JiraIssue` model, `jiraEpicKey`/`jiraEpicUrl` on `Theme`
- `src/index.ts` — Registered Jira routes
- `src/services/settings.service.ts` — Mask Jira API token in GET responses
- `src/services/activity.service.ts` — Added `jira_export` activity type
- `src/services/proposal.service.ts` — Changed NotFound to BadRequest when no themes exist
- `src/routes/proposals.ts` — Added try/catch to prevent server crash on generate

### Frontend (`packages/web`)

**New files:**
- `src/hooks/useJira.ts` — 14 TanStack Query hooks
- `src/components/settings/JiraConfigSection.tsx` — Full config panel
- `src/components/dashboard/JiraSyncWidget.tsx` — Dashboard stats widget

**Modified files:**
- `src/lib/api.ts` — Added `jiraApi` with 14 methods and Jira types
- `src/pages/SettingsPage.tsx` — Added Jira section
- `src/pages/DashboardPage.tsx` — Added Jira widget
- `src/components/feedback/ImportModal.tsx` — Added "From Jira" tab
- `src/components/themes/ThemeDetail.tsx` — Epic export button
- `src/components/themes/ThemeCard.tsx` — Epic badge
- `src/components/proposals/ProposalDetail.tsx` — Jira sync/unlink/attach-spec actions
- `src/components/dashboard/QuickActions.tsx` — Jira shortcut
- `src/components/dashboard/OnboardingSteps.tsx` — Updated import text
- `src/components/dashboard/ActivityFeed.tsx` — Jira export icon

### Tests

**New files:**
- `tests/unit/jira-schema.test.ts` — 12 tests
- `tests/unit/jira-service.test.ts` — 43 tests
- `tests/integration/jira.routes.test.ts` — 33 tests

**Modified files:**
- `tests/setup.ts` — Added `JiraIssue` cleanup
- `tests/helpers/factories.ts` — Added `createJiraIssue()` factory

### Documentation
- `README.md` — Added Jira to features list
- `docs/api-reference.md` — Documented all 15 Jira endpoints
- `docs/architecture.md` — Added Jira to architecture diagram and component table
- `docs/self-hosting.md` — Added Jira setup and webhook config instructions

## API Endpoints

| Method | Endpoint | Description |
|--------|----------|-------------|
| PUT | `/api/jira/config` | Save Jira configuration |
| POST | `/api/jira/test` | Test connection |
| GET | `/api/jira/projects` | List projects |
| GET | `/api/jira/issue-types` | List issue types |
| POST | `/api/jira/export/:proposalId` | Export proposal → Jira issue |
| POST | `/api/jira/sync/:proposalId` | Sync single issue status |
| GET | `/api/jira/issues` | List all exported issues |
| GET | `/api/jira/issues/:proposalId` | Get linked issue |
| DELETE | `/api/jira/issues/:proposalId` | Unlink issue |
| POST | `/api/jira/export-theme/:themeId` | Export theme → Epic + Stories |
| POST | `/api/jira/attach-spec/:proposalId` | Attach PRD as Jira comment |
| POST | `/api/jira/import-feedback` | Import Jira issues as feedback |
| POST | `/api/jira/sync-all` | Bulk sync all linked issues |
| POST | `/api/jira/webhook` | Receive Jira webhooks |
| GET | `/api/jira/dashboard` | Dashboard summary |

## Testing

88 new tests — all passing:

```bash
cd packages/api
nvm use 22
npx vitest run tests/unit/jira-schema.test.ts tests/unit/jira-service.test.ts tests/integration/jira.routes.test.ts