### PR TITLE
ENHANCEMENT: Improve Jira integration with smart field mapping, priority sync, and remote links

### DIFF
--- a/packages/api/src/routes/jira.ts
+++ b/packages/api/src/routes/jira.ts
@@ -67,6 +67,32 @@ router.get('/issue-types', async (_req: Request, res: Response, next: NextFuncti
   }
 });
 
+/**
+ * GET /api/jira/priorities
+ * List available priorities from the Jira instance.
+ */
+router.get('/priorities', async (_req: Request, res: Response, next: NextFunction) => {
+  try {
+    const priorities = await jiraService.listPriorities();
+    res.json({ data: priorities });
+  } catch (err) {
+    next(err);
+  }
+});
+
+/**
+ * GET /api/jira/fields
+ * List custom fields (for finding story points field name).
+ */
+router.get('/fields', async (_req: Request, res: Response, next: NextFunction) => {
+  try {
+    const fields = await jiraService.listFields();
+    res.json({ data: fields });
+  } catch (err) {
+    next(err);
+  }
+});
+
 // ─── Export & Sync ────────────────────────────────────────
 
 /**

--- a/packages/api/src/schemas/jira.schema.ts
+++ b/packages/api/src/schemas/jira.schema.ts
@@ -14,4 +14,7 @@ export const jiraConfigSchema = z.object({
   jira_api_token: z.string().min(1).optional(),
   jira_project_key: z.string().min(1).max(20).optional(),
   jira_issue_type: z.string().min(1).max(50).optional(),
+  jira_story_points_field: z.string().max(100).optional(),
+  jira_done_statuses: z.string().max(500).optional(),
+  jira_epic_name_field: z.string().max(100).optional(),
 });

--- a/packages/api/src/services/jira.service.ts
+++ b/packages/api/src/services/jira.service.ts
@@ -11,6 +11,9 @@ export const JIRA_SETTING_KEYS = {
   JIRA_API_TOKEN: 'jira_api_token',
   JIRA_PROJECT_KEY: 'jira_project_key',
   JIRA_ISSUE_TYPE: 'jira_issue_type',
+  JIRA_STORY_POINTS_FIELD: 'jira_story_points_field',
+  JIRA_DONE_STATUSES: 'jira_done_statuses',
+  JIRA_EPIC_NAME_FIELD: 'jira_epic_name_field',
 } as const;
 
 // ─── Types ────────────────────────────────────────────────
@@ -21,6 +24,9 @@ interface JiraConfig {
   apiToken: string;
   projectKey: string;
   issueType: string;
+  storyPointsField: string;
+  doneStatuses: string[];
+  epicNameField: string;
 }
 
 interface JiraProject {
@@ -51,20 +57,90 @@ interface JiraIssueResponse {
   };
 }
 
+// ─── RICE & Priority Mapping Helpers ─────────────────
+
+function getRiceTierLabel(riceScore: number | null): string {
+  if (riceScore === null) return 'rice-unscored';
+  if (riceScore >= 8) return 'rice-high';
+  if (riceScore >= 4) return 'rice-medium';
+  return 'rice-low';
+}
+
+/**
+ * Map average urgency (0-1) to Jira priority name.
+ * Jira Cloud default priorities: Highest, High, Medium, Low, Lowest
+ */
+function urgencyToJiraPriority(
+  evidence: { feedbackItem: { urgency?: number | null } }[],
+): string | null {
+  if (!evidence.length) return null;
+  const avgUrgency =
+    evidence.reduce((sum, e) => {
+      const u = (e.feedbackItem as { urgency?: number | null }).urgency;
+      return sum + (typeof u === 'number' ? u : 0.5);
+    }, 0) / evidence.length;
+  if (avgUrgency >= 0.8) return 'Highest';
+  if (avgUrgency >= 0.6) return 'High';
+  if (avgUrgency >= 0.4) return 'Medium';
+  if (avgUrgency >= 0.2) return 'Low';
+  return 'Lowest';
+}
+
+/**
+ * Map effort score (1-10) to Fibonacci story points.
+ */
+function effortToStoryPoints(effortScore: number | null): number | null {
+  if (effortScore === null) return null;
+  const map: Record<number, number> = {
+    1: 1,
+    2: 2,
+    3: 3,
+    4: 5,
+    5: 8,
+    6: 8,
+    7: 13,
+    8: 13,
+    9: 21,
+    10: 21,
+  };
+  return map[effortScore] ?? null;
+}
+
 // ─── Helpers ──────────────────────────────────────────────
 
+const DEFAULT_DONE_STATUSES = ['done', 'closed', 'resolved', 'released'];
+
 async function getJiraConfig(): Promise<JiraConfig> {
-  const [host, email, apiToken, projectKey, issueType] = await Promise.all([
+  const [
+    host,
+    email,
+    apiToken,
+    projectKey,
+    issueType,
+    storyPointsField,
+    doneStatuses,
+    epicNameField,
+  ] = await Promise.all([
     settingsService.getRaw(JIRA_SETTING_KEYS.JIRA_HOST),
     settingsService.getRaw(JIRA_SETTING_KEYS.JIRA_EMAIL),
     settingsService.getRaw(JIRA_SETTING_KEYS.JIRA_API_TOKEN),
     settingsService.getRaw(JIRA_SETTING_KEYS.JIRA_PROJECT_KEY),
     settingsService.getRaw(JIRA_SETTING_KEYS.JIRA_ISSUE_TYPE),
+    settingsService.getRaw(JIRA_SETTING_KEYS.JIRA_STORY_POINTS_FIELD),
+    settingsService.getRaw(JIRA_SETTING_KEYS.JIRA_DONE_STATUSES),
+    settingsService.getRaw(JIRA_SETTING_KEYS.JIRA_EPIC_NAME_FIELD),
   ]);
 
   if (!host || !email || !apiToken) {
     throw BadRequest('Jira is not configured. Please set host, email, and API token in settings.');
   }
+
+  const parsedDoneStatuses = doneStatuses
+    ? doneStatuses
+        .split(',')
+        .map((s) => s.trim().toLowerCase())
+        .filter(Boolean)
+    : DEFAULT_DONE_STATUSES;
 
   return {
     host: host.replace(/\/+$/, ''), // strip trailing slashes
@@ -72,6 +148,9 @@ async function getJiraConfig(): Promise<JiraConfig> {
     apiToken,
     projectKey: projectKey || '',
     issueType: issueType || 'Story',
+    storyPointsField: storyPointsField || 'story_points',
+    doneStatuses: parsedDoneStatuses,
+    epicNameField: epicNameField || '',
   };
 }
 
@@ -157,6 +236,31 @@ export const jiraService = {
   },
 
   /**
+   * List available priorities from the Jira instance.
+   * Allows users to see what their instance supports (varies by org).
+   */
+  async listPriorities(): Promise<{ id: string; name: string }[]> {
+    const config = await getJiraConfig();
+    const data = await jiraFetch<{ id: string; name: string; iconUrl?: string }[]>(
+      config,
+      '/priority',
+    );
+    return data.map((p) => ({ id: p.id, name: p.name }));
+  },
+
+  /**
+   * List custom fields from the Jira instance.
+   * Helps users find the correct story points field name.
+   */
+  async listFields(): Promise<{ id: string; name: string; custom: boolean }[]> {
+    const config = await getJiraConfig();
+    const data = await jiraFetch<{ id: string; name: string; custom: boolean }[]>(config, '/field');
+    return data
+      .filter((f) => f.custom || f.name.toLowerCase().includes('story point'))
+      .map((f) => ({ id: f.id, name: f.name, custom: f.custom }));
+  },
+
+  /**
    * Export a proposal to Jira as a new issue.
    */
   async exportProposal(proposalId: string): Promise<{
@@ -180,7 +284,7 @@ export const jiraService = {
     const proposal = await prisma.proposal.findUnique({
       where: { id: proposalId },
       include: {
-        theme: { select: { name: true } },
+        theme: { select: { name: true, category: true } },
         evidence: {
           take: 10,
           orderBy: { relevanceScore: 'desc' },
@@ -196,18 +300,37 @@ export const jiraService = {
     // Build description in Atlassian Document Format (ADF)
     const descriptionAdf = buildJiraDescription(proposal);
 
-    const issueData = {
-      fields: {
-        project: { key: config.projectKey },
-        summary: proposal.title,
-        description: descriptionAdf,
-        issuetype: { name: config.issueType },
-        labels: [
-          'shipscope',
-          proposal.theme?.name ? `theme-${slugify(proposal.theme.name)}` : '',
-        ].filter(Boolean),
-      },
+    // RICE tier label + category label
+    const riceTierLabel = getRiceTierLabel(proposal.riceScore);
+    const categoryLabel = proposal.theme?.category
+      ? `category-${slugify(proposal.theme.category)}`
+      : '';
+
+    // Priority from evidence urgency
+    const priority = urgencyToJiraPriority(
+      proposal.evidence as { feedbackItem: { urgency?: number | null } }[],
+    );
+
+    // Story points from effort
+    const storyPoints = effortToStoryPoints(proposal.effortScore);
+
+    const fields: Record<string, unknown> = {
+      project: { key: config.projectKey },
+      summary: proposal.title,
+      description: descriptionAdf,
+      issuetype: { name: config.issueType },
+      labels: [
+        'shipscope',
+        riceTierLabel,
+        proposal.theme?.name ? `theme-${slugify(proposal.theme.name)}` : '',
+        categoryLabel,
+      ].filter(Boolean),
     };
+
+    if (priority) fields.priority = { name: priority };
+    if (storyPoints !== null) fields[config.storyPointsField] = storyPoints;
+
+    const issueData = { fields };
 
     const result = await jiraFetch<JiraCreateResponse>(config, '/issue', {
       method: 'POST',
@@ -215,6 +338,26 @@ export const jiraService = {
     });
 
     const jiraUrl = `${config.host}/browse/${result.key}`;
+
+    // Add backlink to ShipScope as a Remote Link
+    try {
+      await jiraFetch(config, `/issue/${encodeURIComponent(result.key)}/remotelink`, {
+        method: 'POST',
+        body: JSON.stringify({
+          globalId: `shipscope-proposal-${proposalId}`,
+          application: { type: 'com.shipscope', name: 'ShipScope' },
+          relationship: 'source',
+          object: {
+            url: `${process.env.WEB_URL || 'http://localhost:3000'}/proposals?id=${proposalId}`,
+            title: 'View in ShipScope',
+            summary: `Proposal: ${proposal.title}`,
+            icon: { url16x16: `${process.env.WEB_URL || 'http://localhost:3000'}/favicon.ico` },
+          },
+        }),
+      });
+    } catch {
+      logger.warn(`Could not create remote link for ${result.key}`);
+    }
 
     // Store the link in our database
     const jiraIssue = await prisma.jiraIssue.create({
@@ -314,7 +457,7 @@ export const jiraService = {
       include: {
         proposals: {
           include: {
-            theme: { select: { name: true } },
+            theme: { select: { name: true, category: true } },
             jiraIssue: true,
             evidence: {
               take: 5,
@@ -336,15 +479,20 @@ export const jiraService = {
     }
 
     // 1. Create Epic
-    const epicData = {
-      fields: {
-        project: { key: config.projectKey },
-        summary: theme.name,
-        description: buildEpicDescription(theme),
-        issuetype: { name: 'Epic' },
-        labels: ['shipscope', `category-${theme.category || 'general'}`],
-      },
+    const epicFields: Record<string, unknown> = {
+      project: { key: config.projectKey },
+      summary: theme.name,
+      description: buildEpicDescription(theme),
+      issuetype: { name: 'Epic' },
+      labels: ['shipscope', `category-${theme.category || 'general'}`],
     };
+
+    // Some Jira instances require Epic Name in a custom field
+    if (config.epicNameField) {
+      epicFields[config.epicNameField] = theme.name;
+    }
+
+    const epicData = { fields: epicFields };
 
     const epicResult = await jiraFetch<JiraCreateResponse>(config, '/issue', {
       method: 'POST',
@@ -352,6 +500,25 @@ export const jiraService = {
     });
 
     const epicUrl = `${config.host}/browse/${epicResult.key}`;
+
+    // Remote link for the epic
+    try {
+      await jiraFetch(config, `/issue/${encodeURIComponent(epicResult.key)}/remotelink`, {
+        method: 'POST',
+        body: JSON.stringify({
+          globalId: `shipscope-theme-${themeId}`,
+          application: { type: 'com.shipscope', name: 'ShipScope' },
+          relationship: 'source',
+          object: {
+            url: `${process.env.WEB_URL || 'http://localhost:3000'}/themes?id=${themeId}`,
+            title: 'View Theme in ShipScope',
+            summary: `Theme: ${theme.name}`,
+          },
+        }),
+      });
+    } catch {
+      logger.warn(`Could not create remote link for epic ${epicResult.key}`);
+    }
 
     // Save Epic link on theme
     await prisma.theme.update({
@@ -372,21 +539,46 @@ export const jiraService = {
       try {
         const descriptionAdf = buildJiraDescription(proposal);
 
-        const storyData = {
-          fields: {
-            project: { key: config.projectKey },
-            summary: proposal.title,
-            description: descriptionAdf,
-            issuetype: { name: config.issueType || 'Story' },
-            labels: ['shipscope', `theme-${slugify(theme.name)}`],
-            parent: { key: epicResult.key },
-          },
+        const riceTierLabel = getRiceTierLabel(proposal.riceScore);
+        const priority = urgencyToJiraPriority(
+          proposal.evidence as { feedbackItem: { urgency?: number | null } }[],
+        );
+        const storyPoints = effortToStoryPoints(proposal.effortScore);
+
+        const storyFields: Record<string, unknown> = {
+          project: { key: config.projectKey },
+          summary: proposal.title,
+          description: descriptionAdf,
+          issuetype: { name: config.issueType || 'Story' },
+          labels: ['shipscope', riceTierLabel, `theme-${slugify(theme.name)}`].filter(Boolean),
+          parent: { key: epicResult.key },
         };
+
+        if (priority) storyFields.priority = { name: priority };
+        if (storyPoints !== null) storyFields[config.storyPointsField] = storyPoints;
 
         const storyResult = await jiraFetch<JiraCreateResponse>(config, '/issue', {
           method: 'POST',
-          body: JSON.stringify(storyData),
+          body: JSON.stringify({ fields: storyFields }),
         });
+
+        // Remote link back to ShipScope
+        try {
+          await jiraFetch(config, `/issue/${encodeURIComponent(storyResult.key)}/remotelink`, {
+            method: 'POST',
+            body: JSON.stringify({
+              globalId: `shipscope-proposal-${proposal.id}`,
+              application: { type: 'com.shipscope', name: 'ShipScope' },
+              relationship: 'source',
+              object: {
+                url: `${process.env.WEB_URL || 'http://localhost:3000'}/proposals?id=${proposal.id}`,
+                title: 'View in ShipScope',
+              },
+            }),
+          });
+        } catch {
+          /* non-critical */
+        }
 
         await prisma.jiraIssue.create({
           data: {
@@ -581,9 +773,8 @@ export const jiraService = {
         });
 
         // Auto-mark proposal as "shipped" when Jira issue is Done
-        const doneStatuses = ['done', 'closed', 'resolved', 'released'];
         if (
-          doneStatuses.includes(newStatus.toLowerCase()) &&
+          config.doneStatuses.includes(newStatus.toLowerCase()) &&
           jiraIssue.proposal.status !== 'shipped'
         ) {
           await prisma.proposal.update({
@@ -646,7 +837,13 @@ export const jiraService = {
     });
 
     // Auto-ship proposal if Jira issue is done
-    const doneStatuses = ['done', 'closed', 'resolved', 'released'];
+    let doneStatuses: string[];
+    try {
+      const config = await getJiraConfig();
+      doneStatuses = config.doneStatuses;
+    } catch {
+      doneStatuses = DEFAULT_DONE_STATUSES;
+    }
     if (doneStatuses.includes(newStatus.toLowerCase())) {
       const proposal = await prisma.proposal.findUnique({
         where: { id: jiraIssue.proposalId },
@@ -737,7 +934,7 @@ interface ProposalWithEvidence {
   confidenceScore: number | null;
   effortScore: number | null;
   riceScore: number | null;
-  theme: { name: string } | null;
+  theme: { name: string; category?: string | null } | null;
   evidence: {
     feedbackItem: { content: string; author: string | null; channel: string | null };
   }[];
@@ -797,6 +994,30 @@ function buildJiraDescription(proposal: ProposalWithEvidence) {
       })),
     });
   }
+
+  // Acceptance criteria stub
+  content.push(heading('Acceptance Criteria'));
+  content.push({
+    type: 'bulletList',
+    content: [
+      {
+        type: 'listItem',
+        content: [
+          paragraph(
+            `User can ${proposal.solution.slice(0, 100).toLowerCase().replace(/[.]+$/, '')}`,
+          ),
+        ],
+      },
+      {
+        type: 'listItem',
+        content: [paragraph('Edge cases are handled gracefully with user-facing error messages')],
+      },
+      {
+        type: 'listItem',
+        content: [paragraph('Feature is covered by automated tests')],
+      },
+    ],
+  });
 
   // Generated by
   content.push({

--- a/packages/api/tests/integration/jira.routes.test.ts
+++ b/packages/api/tests/integration/jira.routes.test.ts
@@ -68,6 +68,29 @@ describe('Jira Routes', () => {
       expect(res.body.data.saved).toBe(true);
     });
 
+    it('saves advanced config fields', async () => {
+      const res = await request(app)
+        .put('/api/jira/config')
+        .send({
+          jira_story_points_field: 'customfield_10016',
+          jira_done_statuses: 'Deployed, Live',
+          jira_epic_name_field: 'customfield_10011',
+        })
+        .expect(200);
+
+      expect(res.body.data.saved).toBe(true);
+
+      const spField = await prisma.setting.findUnique({
+        where: { key: 'jira_story_points_field' },
+      });
+      expect(spField!.value).toBe('customfield_10016');
+
+      const doneStatuses = await prisma.setting.findUnique({
+        where: { key: 'jira_done_statuses' },
+      });
+      expect(doneStatuses!.value).toBe('Deployed, Live');
+    });
+
     it('rejects non-HTTPS host', async () => {
       await request(app)
         .put('/api/jira/config')
@@ -134,6 +157,39 @@ describe('Jira Routes', () => {
 
       expect(res.body.data).toHaveLength(1);
       expect(res.body.data[0].name).toBe('Story');
+    });
+  });
+
+  // ─── GET /api/jira/priorities ──────────────────────────
+
+  describe('GET /api/jira/priorities', () => {
+    it('returns priorities from Jira', async () => {
+      await seedJiraConfig();
+      mockFetch([
+        { id: '1', name: 'Highest' },
+        { id: '2', name: 'High' },
+        { id: '3', name: 'Medium' },
+      ]);
+
+      const res = await request(app).get('/api/jira/priorities').expect(200);
+      expect(res.body.data).toHaveLength(3);
+      expect(res.body.data[0].name).toBe('Highest');
+    });
+  });
+
+  // ─── GET /api/jira/fields ─────────────────────────────
+
+  describe('GET /api/jira/fields', () => {
+    it('returns custom fields from Jira', async () => {
+      await seedJiraConfig();
+      mockFetch([
+        { id: 'customfield_10016', name: 'Story Points', custom: true },
+        { id: 'summary', name: 'Summary', custom: false },
+      ]);
+
+      const res = await request(app).get('/api/jira/fields').expect(200);
+      expect(res.body.data).toHaveLength(1); // only custom fields
+      expect(res.body.data[0].id).toBe('customfield_10016');
     });
   });
 

--- a/packages/api/tests/unit/jira-service.test.ts
+++ b/packages/api/tests/unit/jira-service.test.ts
@@ -119,6 +119,43 @@ describe('Jira Service', () => {
     });
   });
 
+  // ─── listPriorities ────────────────────────────────────
+
+  describe('listPriorities', () => {
+    it('returns priorities from Jira', async () => {
+      await seedJiraConfig();
+      mockFetch([
+        { id: '1', name: 'Highest', iconUrl: 'url' },
+        { id: '2', name: 'High', iconUrl: 'url' },
+        { id: '3', name: 'Medium', iconUrl: 'url' },
+      ]);
+
+      const priorities = await jiraService.listPriorities();
+      expect(priorities).toHaveLength(3);
+      expect(priorities[0].name).toBe('Highest');
+    });
+  });
+
+  // ─── listFields ────────────────────────────────────────
+
+  describe('listFields', () => {
+    it('returns custom fields and story point fields', async () => {
+      await seedJiraConfig();
+      mockFetch([
+        { id: 'summary', name: 'Summary', custom: false },
+        { id: 'customfield_10016', name: 'Story Points', custom: true },
+        { id: 'customfield_10020', name: 'Sprint', custom: true },
+        { id: 'story_points', name: 'Story point estimate', custom: false },
+      ]);
+
+      const fields = await jiraService.listFields();
+      // Should return custom fields + any field matching "story point"
+      expect(fields.length).toBeGreaterThanOrEqual(3);
+      expect(fields.find((f) => f.id === 'customfield_10016')).toBeTruthy();
+      expect(fields.find((f) => f.id === 'story_points')).toBeTruthy();
+    });
+  });
+
   // ─── exportProposal ────────────────────────────────────
 
   describe('exportProposal', () => {
@@ -127,11 +164,26 @@ describe('Jira Service', () => {
       const theme = await createTheme();
       const proposal = await createProposal(theme.id);
 
-      mockFetch({
-        id: '10001',
-        key: 'PROJ-42',
-        self: 'https://test.atlassian.net/rest/api/3/issue/10001',
-      });
+      const fetchSpy = vi.spyOn(globalThis, 'fetch');
+      // 1. Create issue
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            id: '10001',
+            key: 'PROJ-42',
+            self: 'https://test.atlassian.net/rest/api/3/issue/10001',
+          }),
+        text: () => Promise.resolve(''),
+      } as Response);
+      // 2. Remote link (backlink)
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ id: 1 }),
+        text: () => Promise.resolve(''),
+      } as Response);
 
       const result = await jiraService.exportProposal(proposal.id);
       expect(result.jiraKey).toBe('PROJ-42');
@@ -166,20 +218,39 @@ describe('Jira Service', () => {
       await expect(jiraService.exportProposal(proposal.id)).rejects.toThrow('project key');
     });
 
-    it('sends correct request to Jira API', async () => {
+    it('sends correct request with RICE labels, priority, and story points', async () => {
       await seedJiraConfig();
-      const theme = await createTheme({ name: 'Performance Issues' });
+      const theme = await createTheme({ name: 'Performance Issues', category: 'performance' });
       const proposal = await createProposal(theme.id, {
         title: 'Optimize Database Queries',
         problem: 'Slow queries',
         solution: 'Add indexes',
+        riceScore: 9.0,
+        reachScore: 8,
+        impactScore: 9,
+        confidenceScore: 8,
+        effortScore: 3,
       });
 
-      const fetchSpy = mockFetch({ id: '10001', key: 'PROJ-1', self: '' });
+      const fetchSpy = vi.spyOn(globalThis, 'fetch');
+      // 1. Create issue
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ id: '10001', key: 'PROJ-1', self: '' }),
+        text: () => Promise.resolve(''),
+      } as Response);
+      // 2. Create remote link (backlink)
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ id: 1 }),
+        text: () => Promise.resolve(''),
+      } as Response);
 
       await jiraService.exportProposal(proposal.id);
 
-      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      // Verify issue creation payload
       const [url, options] = fetchSpy.mock.calls[0];
       expect(url).toBe('https://test.atlassian.net/rest/api/3/issue');
       expect(options?.method).toBe('POST');
@@ -189,7 +260,41 @@ describe('Jira Service', () => {
       expect(body.fields.summary).toBe('Optimize Database Queries');
       expect(body.fields.issuetype.name).toBe('Story');
       expect(body.fields.labels).toContain('shipscope');
+      expect(body.fields.labels).toContain('rice-high');
       expect(body.fields.labels).toContain('theme-performance-issues');
+      expect(body.fields.labels).toContain('category-performance');
+      expect(body.fields.story_points).toBe(3); // effort 3 → 3 story points
+
+      // Verify remote link was created
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+      const [linkUrl] = fetchSpy.mock.calls[1];
+      expect(linkUrl).toContain('/remotelink');
+    });
+
+    it('uses custom story points field when configured', async () => {
+      await seedJiraConfig({ [JIRA_SETTING_KEYS.JIRA_STORY_POINTS_FIELD]: 'customfield_10016' });
+      const theme = await createTheme();
+      const proposal = await createProposal(theme.id, { effortScore: 5 });
+
+      const fetchSpy = vi.spyOn(globalThis, 'fetch');
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ id: '10002', key: 'PROJ-2', self: '' }),
+        text: () => Promise.resolve(''),
+      } as Response);
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ id: 2 }),
+        text: () => Promise.resolve(''),
+      } as Response);
+
+      await jiraService.exportProposal(proposal.id);
+
+      const body = JSON.parse(fetchSpy.mock.calls[0][1]?.body as string);
+      expect(body.fields.customfield_10016).toBe(8); // effort 5 → 8 story points
+      expect(body.fields.story_points).toBeUndefined();
     });
   });
 
@@ -619,6 +724,26 @@ describe('Jira Service', () => {
 
       expect(result.processed).toBe(true);
       // Status should remain shipped (no extra update)
+      const updatedProposal = await prisma.proposal.findUnique({ where: { id: proposal.id } });
+      expect(updatedProposal!.status).toBe('shipped');
+    });
+
+    it('auto-ships using custom done statuses', async () => {
+      // Configure custom done statuses
+      await seedJiraConfig({
+        [JIRA_SETTING_KEYS.JIRA_DONE_STATUSES]: 'Deployed, Live in Production',
+      });
+      const theme = await createTheme();
+      const proposal = await createProposal(theme.id, { status: 'approved' });
+      await createJiraIssue(proposal.id, { jiraKey: 'PROJ-CUSTOM' });
+
+      await jiraService.handleWebhook({
+        issue: {
+          key: 'PROJ-CUSTOM',
+          fields: { status: { name: 'Deployed' }, summary: 'Custom done' },
+        },
+      });
+
       const updatedProposal = await prisma.proposal.findUnique({ where: { id: proposal.id } });
       expect(updatedProposal!.status).toBe('shipped');
     });

--- a/packages/web/src/components/settings/JiraConfigSection.tsx
+++ b/packages/web/src/components/settings/JiraConfigSection.tsx
@@ -19,6 +19,7 @@ import {
   useJiraIssues,
   useJiraImportFeedback,
   useJiraSyncAll,
+  useJiraFields,
 } from '@/hooks/useJira';
 
 interface JiraConfigSectionProps {
@@ -33,6 +34,12 @@ export function JiraConfigSection({ settings, onUpdate }: JiraConfigSectionProps
   const [showToken, setShowToken] = useState(false);
   const [projectKey, setProjectKey] = useState(settings['jira_project_key'] || '');
   const [issueType, setIssueType] = useState(settings['jira_issue_type'] || 'Story');
+  const [storyPointsField, setStoryPointsField] = useState(
+    settings['jira_story_points_field'] || '',
+  );
+  const [doneStatuses, setDoneStatuses] = useState(settings['jira_done_statuses'] || '');
+  const [epicNameField, setEpicNameField] = useState(settings['jira_epic_name_field'] || '');
+  const [showAdvanced, setShowAdvanced] = useState(false);
 
   const [jql, setJql] = useState('');
   const [copiedWebhook, setCopiedWebhook] = useState(false);
@@ -41,6 +48,7 @@ export function JiraConfigSection({ settings, onUpdate }: JiraConfigSectionProps
   const saveMutation = useJiraSaveConfig();
   const projectsQuery = useJiraProjects();
   const issueTypesQuery = useJiraIssueTypes();
+  const fieldsQuery = useJiraFields();
   const { data: jiraIssues } = useJiraIssues();
   const importMutation = useJiraImportFeedback();
   const syncAllMutation = useJiraSyncAll();
@@ -56,6 +64,10 @@ export function JiraConfigSection({ settings, onUpdate }: JiraConfigSectionProps
     if (apiToken.trim()) config['jira_api_token'] = apiToken.trim();
     if (projectKey.trim()) config['jira_project_key'] = projectKey.trim();
     if (issueType.trim()) config['jira_issue_type'] = issueType.trim();
+    // Advanced fields — save even if empty (to clear previous values)
+    config['jira_story_points_field'] = storyPointsField.trim();
+    config['jira_done_statuses'] = doneStatuses.trim();
+    config['jira_epic_name_field'] = epicNameField.trim();
 
     saveMutation.mutate(config, {
       onSuccess: () => {
@@ -243,6 +255,109 @@ export function JiraConfigSection({ settings, onUpdate }: JiraConfigSectionProps
           Test Connection
         </Button>
       </div>
+
+      {/* Advanced Configuration */}
+      {isConfigured && (
+        <div className="pt-4 border-t border-border">
+          <button
+            type="button"
+            onClick={() => setShowAdvanced(!showAdvanced)}
+            className="text-sm font-medium text-text-secondary hover:text-text-primary flex items-center gap-1"
+          >
+            {showAdvanced ? '▾' : '▸'} Advanced Configuration
+          </button>
+          <p className="text-[10px] text-text-muted mt-1">
+            Customize field mappings for your organization&apos;s Jira setup.
+          </p>
+
+          {showAdvanced && (
+            <div className="mt-3 space-y-4">
+              {/* Story Points Field */}
+              <div>
+                <div className="flex items-end gap-2">
+                  <div className="flex-1">
+                    <label className="text-sm font-medium text-text-primary block mb-1.5">
+                      Story Points Field
+                    </label>
+                    {fieldsQuery.data && fieldsQuery.data.length > 0 ? (
+                      <select
+                        value={storyPointsField}
+                        onChange={(e) => setStoryPointsField(e.target.value)}
+                        className="w-full bg-bg-surface-2 border border-border rounded-lg px-3 py-2 text-sm text-text-primary"
+                      >
+                        <option value="">Default (story_points)</option>
+                        {fieldsQuery.data.map((f) => (
+                          <option key={f.id} value={f.id}>
+                            {f.id} — {f.name}
+                          </option>
+                        ))}
+                      </select>
+                    ) : (
+                      <input
+                        type="text"
+                        value={storyPointsField}
+                        onChange={(e) => setStoryPointsField(e.target.value)}
+                        placeholder="e.g. customfield_10016 (leave blank for default)"
+                        className="w-full bg-bg-surface-2 border border-border rounded-lg px-3 py-2 text-sm text-text-primary placeholder:text-text-muted font-mono"
+                      />
+                    )}
+                  </div>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => fieldsQuery.refetch()}
+                    loading={fieldsQuery.isFetching}
+                    title="Load fields from Jira"
+                  >
+                    <RefreshCw size={14} />
+                  </Button>
+                </div>
+                <p className="text-[10px] text-text-muted mt-1">
+                  Many orgs use a custom field like{' '}
+                  <code className="text-[10px]">customfield_10016</code>. Click refresh to
+                  auto-detect.
+                </p>
+              </div>
+
+              {/* Done Statuses */}
+              <div>
+                <label className="text-sm font-medium text-text-primary block mb-1.5">
+                  Done Statuses
+                </label>
+                <input
+                  type="text"
+                  value={doneStatuses}
+                  onChange={(e) => setDoneStatuses(e.target.value)}
+                  placeholder="Done, Closed, Resolved, Released"
+                  className="w-full bg-bg-surface-2 border border-border rounded-lg px-3 py-2 text-sm text-text-primary placeholder:text-text-muted"
+                />
+                <p className="text-[10px] text-text-muted mt-1">
+                  Comma-separated list of Jira statuses that mark a proposal as shipped. Leave blank
+                  for defaults.
+                </p>
+              </div>
+
+              {/* Epic Name Field */}
+              <div>
+                <label className="text-sm font-medium text-text-primary block mb-1.5">
+                  Epic Name Field (optional)
+                </label>
+                <input
+                  type="text"
+                  value={epicNameField}
+                  onChange={(e) => setEpicNameField(e.target.value)}
+                  placeholder="e.g. customfield_10011 (leave blank if not needed)"
+                  className="w-full bg-bg-surface-2 border border-border rounded-lg px-3 py-2 text-sm text-text-primary placeholder:text-text-muted font-mono"
+                />
+                <p className="text-[10px] text-text-muted mt-1">
+                  Some Jira instances require an &ldquo;Epic Name&rdquo; custom field when creating
+                  Epics.
+                </p>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
 
       {saveMutation.isSuccess && (
         <p className="text-xs text-success flex items-center gap-1">

--- a/packages/web/src/hooks/useJira.ts
+++ b/packages/web/src/hooks/useJira.ts
@@ -35,6 +35,24 @@ export function useJiraIssueTypes() {
   });
 }
 
+export function useJiraPriorities() {
+  return useQuery({
+    queryKey: ['jira', 'priorities'],
+    queryFn: () => jiraApi.listPriorities(),
+    enabled: false,
+    retry: false,
+  });
+}
+
+export function useJiraFields() {
+  return useQuery({
+    queryKey: ['jira', 'fields'],
+    queryFn: () => jiraApi.listFields(),
+    enabled: false,
+    retry: false,
+  });
+}
+
 export function useJiraExport() {
   const queryClient = useQueryClient();
   return useMutation({

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -536,6 +536,15 @@ export const jiraApi = {
   listIssueTypes: () =>
     api.get<{ data: JiraIssueType[] }>('/jira/issue-types').then((r) => r.data.data),
 
+  // Discovery endpoints (for org-specific configuration)
+  listPriorities: () =>
+    api.get<{ data: { id: string; name: string }[] }>('/jira/priorities').then((r) => r.data.data),
+
+  listFields: () =>
+    api
+      .get<{ data: { id: string; name: string; custom: boolean }[] }>('/jira/fields')
+      .then((r) => r.data.data),
+
   // Export & Sync
   exportProposal: (proposalId: string) =>
     api.post<{ data: JiraExportResult }>(`/jira/export/${proposalId}`).then((r) => r.data.data),


### PR DESCRIPTION
Closes #29 
## What

Upgrades the Jira integration from basic export to an enterprise-grade workflow with smart field mapping, bi-directional linking, and org-specific configuration.

## Changes

### Backend (`packages/api`)

**`src/services/jira.service.ts`** (core enhancements)
- **RICE tier labels** — Exported issues now get `rice-high`, `rice-medium`, or `rice-low` labels based on RICE score
- **Priority mapping** — Evidence urgency scores are aggregated and mapped to Jira priorities (`Highest → Lowest`)
- **Story points** — Effort scores are converted to Fibonacci story points (1, 2, 3, 5, 8, 13, 21) and written to a configurable custom field
- **Remote Links** — Every exported issue and epic gets a Jira Remote Link pointing back to the ShipScope proposal/theme (with app icon)
- **Acceptance criteria** — ADF description now includes an auto-generated AC section with contextual criteria
- **`listPriorities()`** — New method to fetch available priorities from the Jira instance
- **`listFields()`** — New method to list custom fields (filtered to custom + story point fields) for field discovery
- **Configurable done statuses** — `doneStatuses` pulled from settings instead of hardcoded, with sensible defaults
- **Epic Name field** — Configurable `epicNameField` for Jira orgs that require it on epic creation
- **Category labels** — Theme category is now exported as a `category-*` label

**`src/routes/jira.ts`**
- `GET /api/jira/priorities` — List instance priorities
- `GET /api/jira/fields` — List custom fields for configuration

**`src/schemas/jira.schema.ts`**
- Added `jira_story_points_field`, `jira_done_statuses`, `jira_epic_name_field` to config schema

### Frontend (`packages/web`)

**`src/components/settings/JiraConfigSection.tsx`**
- New collapsible **Advanced Configuration** section with:
  - Story Points Field selector (auto-populated from Jira fields or manual input)
  - Done Statuses input (comma-separated)
  - Epic Name Field input
- Fields are saved on config save (including clearing empty values)

**`src/hooks/useJira.ts`**
- `useJiraPriorities()` — Query hook for priorities endpoint
- `useJiraFields()` — Query hook for fields endpoint

**`src/lib/api.ts`**
- `jiraApi.listPriorities()` and `jiraApi.listFields()` client methods

### Tests

**`tests/unit/jira-service.test.ts`** — New tests for:
- `listPriorities()` returns mapped priorities
- `listFields()` filters to custom + story point fields

**`tests/integration/jira.routes.test.ts`** — New tests for:
- `PUT /api/jira/config` saves advanced config fields
- `GET /api/jira/priorities` returns priorities from Jira
- `GET /api/jira/fields` returns custom fields

## Files Changed

| File | Changes |
|------|---------|
| `packages/api/src/services/jira.service.ts` | +257 / −45 |
| `packages/web/src/components/settings/JiraConfigSection.tsx` | +109 |
| `packages/api/tests/unit/jira-service.test.ts` | +134 |
| `packages/api/tests/integration/jira.routes.test.ts` | +52 |
| `packages/api/src/routes/jira.ts` | +26 |
| `packages/web/src/hooks/useJira.ts` | +18 |
| `packages/web/src/lib/api.ts` | +7 |
| `packages/api/src/schemas/jira.schema.ts` | +3 |
| **Total** | **+561 / −45 across 8 files** |

## Testing

```bash
cd packages/api
npx vitest run tests/unit/jira-service.test.ts tests/integration/jira.routes.test.ts