### PR TITLE
FEATURE: Add Linear integration with bi-directional sync, webhook security, and rich attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ graph LR
 - **Spec Generation** — Generate PRDs and agent-ready prompts from approved proposals
 - **Jira Integration** — Bi-directional sync: export proposals/epics to Jira, import Jira issues as feedback, real-time webhook sync
 - **Trello Integration** — Export proposals as cards, themes as lists, import Trello cards as feedback, real-time webhook sync
+- **Linear Integration** — Export proposals as issues, themes as projects, import Linear issues as feedback, real-time webhook sync
 - **Dashboard** — Overview of feedback volume, sentiment trends, and top themes
-- **Settings** — AI config, synthesis tuning, Jira configuration, Trello configuration, data management, API key management
+- **Settings** — AI config, synthesis tuning, Jira configuration, Trello configuration, Linear configuration, data management, API key management
 
 ## Quick Start
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -749,3 +749,273 @@ Get Trello integration summary for the dashboard widget.
   }
 }
 ```
+
+---
+
+## Linear Integration
+
+All Linear endpoints are prefixed with `/api/linear`.
+
+### PUT /api/linear/config
+
+Save Linear integration configuration.
+
+**Request Body:**
+
+```json
+{
+  "linear_api_key": "lin_api_...",
+  "linear_team_id": "team-uuid",
+  "linear_project_id": "project-uuid",
+  "linear_done_states": "Done,Cancelled",
+  "linear_default_label_id": "label-uuid",
+  "linear_cycle_id": "cycle-uuid"
+}
+```
+
+All fields are optional. Provide only the fields you want to update.
+
+**Response 200:**
+
+```json
+{ "data": { "saved": true } }
+```
+
+### POST /api/linear/test
+
+Test the Linear connection with current credentials.
+
+**Response 200:**
+
+```json
+{
+  "data": {
+    "success": true,
+    "message": "Connected as User Name (user@email.com)",
+    "userName": "User Name"
+  }
+}
+```
+
+### GET /api/linear/teams
+
+List teams the authenticated user belongs to.
+
+**Response 200:**
+
+```json
+{ "data": [{ "id": "team-uuid", "name": "Engineering", "key": "ENG" }] }
+```
+
+### GET /api/linear/projects
+
+List projects for the configured team.
+
+**Response 200:**
+
+```json
+{
+  "data": [
+    { "id": "proj-uuid", "name": "Q1 Roadmap", "url": "https://linear.app/...", "state": "started" }
+  ]
+}
+```
+
+### GET /api/linear/labels
+
+List labels for the configured team.
+
+**Response 200:**
+
+```json
+{ "data": [{ "id": "label-uuid", "name": "Feature", "color": "#5E6AD2" }] }
+```
+
+### GET /api/linear/states
+
+List workflow states for the configured team.
+
+**Response 200:**
+
+```json
+{ "data": [{ "id": "state-uuid", "name": "In Progress", "type": "started", "color": "#F2C94C" }] }
+```
+
+### GET /api/linear/cycles
+
+List cycles (sprints) for the configured team.
+
+**Response 200:**
+
+```json
+{
+  "data": [
+    {
+      "id": "cycle-uuid",
+      "name": null,
+      "number": 12,
+      "startsAt": "2025-01-01T00:00:00.000Z",
+      "endsAt": "2025-01-14T00:00:00.000Z"
+    }
+  ]
+}
+```
+
+### POST /api/linear/export/:proposalId
+
+Export an approved proposal as a Linear issue.
+
+**Response 201:**
+
+```json
+{
+  "data": {
+    "identifier": "ENG-42",
+    "linearUrl": "https://linear.app/team/issue/ENG-42",
+    "linearId": "issue-uuid",
+    "status": "Backlog",
+    "priority": 3
+  }
+}
+```
+
+### POST /api/linear/sync/:proposalId
+
+Sync the status of a linked Linear issue back to ShipScope.
+
+**Response 200:**
+
+```json
+{ "data": { "status": "In Progress", "priority": 2 } }
+```
+
+### GET /api/linear/issues
+
+List all proposals exported to Linear.
+
+**Response 200:**
+
+```json
+{
+  "data": [
+    {
+      "id": "record-uuid",
+      "proposalId": "proposal-uuid",
+      "identifier": "ENG-42",
+      "linearUrl": "https://linear.app/team/issue/ENG-42",
+      "status": "In Progress",
+      "priority": 2,
+      "issueTitle": "Add dark mode support",
+      "proposal": { "id": "...", "title": "...", "status": "approved" }
+    }
+  ]
+}
+```
+
+### GET /api/linear/issues/:proposalId
+
+Get the linked Linear issue for a specific proposal.
+
+**Response 200:** Same shape as individual items in the list above.
+
+**Response 404:** When no linked issue exists.
+
+### DELETE /api/linear/issues/:proposalId
+
+Unlink a Linear issue from a proposal. The issue in Linear is **not** deleted.
+
+**Response 200:**
+
+```json
+{ "data": { "unlinked": true } }
+```
+
+### POST /api/linear/export-theme/:themeId
+
+Export all proposals under a theme as a Linear project with individual issues.
+
+**Response 201:**
+
+```json
+{
+  "data": {
+    "projectName": "Dark Mode",
+    "projectUrl": "https://linear.app/team/project/dark-mode",
+    "issuesCreated": 5,
+    "issuesSkipped": 1
+  }
+}
+```
+
+### POST /api/linear/attach-spec/:proposalId
+
+Attach the generated PRD spec as a comment on the linked Linear issue.
+
+**Response 200:**
+
+```json
+{ "data": { "attached": true } }
+```
+
+### POST /api/linear/import-feedback
+
+Import Linear issues as feedback items for AI analysis.
+
+**Request Body (optional):**
+
+```json
+{
+  "projectId": "project-uuid",
+  "stateType": "started",
+  "maxResults": 50
+}
+```
+
+**Response 200:**
+
+```json
+{ "data": { "imported": 25, "skipped": 3, "sourceId": "source-uuid" } }
+```
+
+### POST /api/linear/sync-all
+
+Sync status for all exported Linear issues at once.
+
+**Response 200:**
+
+```json
+{ "data": { "synced": 10, "autoShipped": 2, "errors": 0 } }
+```
+
+### POST /api/linear/webhook
+
+Receive Linear webhook events for real-time issue state sync.
+
+**Response 200:**
+
+```json
+{ "data": { "received": true } }
+```
+
+### GET /api/linear/dashboard
+
+Get Linear integration summary for the dashboard widget.
+
+**Response 200:**
+
+```json
+{
+  "data": {
+    "total": 15,
+    "byStatus": [
+      { "status": "In Progress", "count": 8 },
+      { "status": "Done", "count": 5 }
+    ],
+    "byPriority": [
+      { "priority": 1, "count": 3 },
+      { "priority": 2, "count": 7 }
+    ],
+    "recentExports": []
+  }
+}
+```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,6 +45,7 @@ graph TB
     subgraph "External Integrations"
         JIRA[Jira Cloud<br/>REST API v3]
         TRELLO[Trello<br/>REST API]
+        LINEAR[Linear<br/>GraphQL API]
     end
 
     WEB -->|REST API| EXPRESS
@@ -56,6 +57,8 @@ graph TB
     JIRA -->|Webhooks| EXPRESS
     SERVICES -->|Export / Import / Sync| TRELLO
     TRELLO -->|Webhooks| EXPRESS
+    SERVICES -->|Export / Import / Sync| LINEAR
+    LINEAR -->|Webhooks| EXPRESS
     WORKERS -->|Process jobs| REDIS
     WORKERS --> OPENAI
     WORKERS --> PG
@@ -123,6 +126,7 @@ graph TD
 | Service Layer    | Business logic, orchestration, caching          | HTTP concerns, direct Prisma calls in routes |
 | Jira Service     | Jira API integration, export/import/sync        | UI rendering, HTTP concerns                  |
 | Trello Service   | Trello API integration, export/import/sync      | UI rendering, HTTP concerns                  |
+| Linear Service   | Linear API integration, export/import/sync      | UI rendering, HTTP concerns                  |
 | Prisma ORM       | Database queries, migrations, type-safe access  | Business logic, HTTP concerns                |
 | BullMQ Workers   | Background job processing, AI pipeline          | Serving HTTP requests                        |
 | React Components | UI rendering, user interaction                  | Direct API calls (uses TanStack Query)       |
@@ -144,7 +148,7 @@ erDiagram
     }
 ```
 
-Key tables: FeedbackItem, Theme, Proposal, Spec, JiraIssue, TrelloCard, ApiKey, Setting, ActivityLog
+Key tables: FeedbackItem, Theme, Proposal, Spec, JiraIssue, TrelloCard, LinearIssue, ApiKey, Setting, ActivityLog
 
 ## Security Layers
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -137,6 +137,33 @@ https://your-domain.com/api/trello/webhook
 
 When a Trello card moves to a Done/Complete/Shipped/Released/Closed list, ShipScope will automatically mark the linked proposal as "shipped".
 
+## Linear Integration (Optional)
+
+Linear is configured through the Settings UI after deployment — no environment variables needed.
+
+### Setup
+
+1. Go to **Settings → Linear Integration** in the ShipScope UI
+2. Create a personal API key from [linear.app/settings/api](https://linear.app/settings/api)
+3. Enter the API key in settings and click **Test Connection**
+4. Select your default team from the dropdown
+5. Optionally select a project, labels, and cycle
+6. Click **Save**
+
+### Real-Time Sync via Webhooks
+
+To receive instant status updates when Linear issues change:
+
+1. In Linear, go to **Settings → API → Webhooks**
+2. Create a new webhook pointing to:
+   ```
+   https://your-domain.com/api/linear/webhook
+   ```
+3. Select the **Issues** resource and **Data change** event
+4. Save the webhook
+
+When a Linear issue reaches a configured "Done" state, ShipScope will automatically mark the linked proposal as "shipped".
+
 ## Updating
 
 ```bash

--- a/packages/api/prisma/migrations/20260314100000_add_linear_integration/migration.sql
+++ b/packages/api/prisma/migrations/20260314100000_add_linear_integration/migration.sql
@@ -1,0 +1,47 @@
+-- AlterTable
+ALTER TABLE "Theme" ADD COLUMN     "linearProjectId" TEXT,
+ADD COLUMN     "linearProjectUrl" TEXT;
+
+-- CreateTable
+CREATE TABLE "linear_issues" (
+    "id" TEXT NOT NULL,
+    "proposalId" TEXT NOT NULL,
+    "linearId" TEXT NOT NULL,
+    "identifier" TEXT NOT NULL,
+    "linearUrl" TEXT NOT NULL,
+    "teamId" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'Backlog',
+    "priority" INTEGER NOT NULL DEFAULT 0,
+    "issueTitle" TEXT NOT NULL,
+    "projectId" TEXT,
+    "projectName" TEXT,
+    "labelIds" TEXT[],
+    "cycleId" TEXT,
+    "estimate" INTEGER,
+    "syncedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "linear_issues_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "linear_issues_proposalId_idx" ON "linear_issues"("proposalId");
+
+-- CreateIndex
+CREATE INDEX "linear_issues_teamId_idx" ON "linear_issues"("teamId");
+
+-- CreateIndex
+CREATE INDEX "linear_issues_projectId_idx" ON "linear_issues"("projectId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "linear_issues_proposalId_key" ON "linear_issues"("proposalId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "linear_issues_linearId_key" ON "linear_issues"("linearId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "linear_issues_identifier_key" ON "linear_issues"("identifier");
+
+-- AddForeignKey
+ALTER TABLE "linear_issues" ADD CONSTRAINT "linear_issues_proposalId_fkey" FOREIGN KEY ("proposalId") REFERENCES "Proposal"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/api/prisma/schema.prisma
+++ b/packages/api/prisma/schema.prisma
@@ -86,6 +86,10 @@ model Theme {
   trelloBoardListId String?  // Trello list ID where theme cards are created
   trelloBoardListUrl String? // URL to the Trello board
 
+  // Linear Integration
+  linearProjectId   String?  // Linear project ID where theme issues are grouped
+  linearProjectUrl  String?  // Full URL to the Linear project
+
   // Relations
   feedbackItems FeedbackThemeLink[]
   proposals     Proposal[]
@@ -133,8 +137,9 @@ model Proposal {
   theme       Theme?  @relation(fields: [themeId], references: [id])
   evidence    ProposalEvidence[]
   specs       Spec[]
-  jiraIssue   JiraIssue?
-  trelloCard  TrelloCard?
+  jiraIssue    JiraIssue?
+  trelloCard   TrelloCard?
+  linearIssue  LinearIssue?
 
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
@@ -270,4 +275,40 @@ model TrelloCard {
   @@index([proposalId])
   @@index([boardId])
   @@map("trello_cards")
+}
+
+// ============================================
+// LINEAR INTEGRATION
+// ============================================
+
+model LinearIssue {
+  id          String   @id @default(cuid())
+  proposalId  String
+  proposal    Proposal @relation(fields: [proposalId], references: [id])
+
+  // Linear issue data
+  linearId       String   // Linear internal UUID
+  identifier     String   // e.g. "ENG-123"
+  linearUrl      String   // Full URL to the issue
+  teamId         String   // Linear team ID
+  status         String   @default("Backlog")
+  priority       Int      @default(0) // 0=No priority, 1=Urgent, 2=High, 3=Medium, 4=Low
+  issueTitle     String
+  projectId      String?  // Linear project ID (for theme exports)
+  projectName    String?  // Linear project name
+  labelIds       String[] // Applied label IDs
+  cycleId        String?  // Sprint/cycle assignment
+  estimate       Int?     // Story point estimate
+  syncedAt       DateTime @default(now())
+
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  @@unique([proposalId])
+  @@unique([linearId])
+  @@unique([identifier])
+  @@index([proposalId])
+  @@index([teamId])
+  @@index([projectId])
+  @@map("linear_issues")
 }

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -21,6 +21,7 @@ import settingsRoutes from './routes/settings';
 import dashboardRoutes from './routes/dashboard';
 import jiraRoutes from './routes/jira';
 import trelloRoutes from './routes/trello';
+import linearRoutes from './routes/linear';
 
 export function createApp() {
   const app = express();
@@ -66,6 +67,7 @@ export function createApp() {
   app.use('/api/settings', demoGuard, settingsRoutes);
   app.use('/api/jira', demoGuard, jiraRoutes);
   app.use('/api/trello', demoGuard, trelloRoutes);
+  app.use('/api/linear', demoGuard, linearRoutes);
   app.use('/api/dashboard', dashboardRoutes);
 
   // Error handler (must be last)

--- a/packages/api/src/routes/linear.ts
+++ b/packages/api/src/routes/linear.ts
@@ -1,0 +1,451 @@
+import { Router, type Request, type Response, type NextFunction } from 'express';
+import express from 'express';
+import {
+  linearService,
+  verifyWebhookSignature,
+  LINEAR_SETTING_KEYS,
+} from '../services/linear.service';
+import { settingsService } from '../services/settings.service';
+import { activityService } from '../services/activity.service';
+import { validate } from '../middleware/validate';
+import { linearConfigSchema, linearImportSchema } from '../schemas/linear.schema';
+import { AppError } from '../lib/errors';
+import { logger } from '../lib/logger';
+
+const router = Router();
+
+// ─── Configuration ────────────────────────────────────────
+
+/**
+ * PUT /api/linear/config
+ * Save Linear configuration (API key, team, project, cycle, labels).
+ */
+router.put(
+  '/config',
+  validate(linearConfigSchema, 'body'),
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const settings = req.body as Record<string, string>;
+      await settingsService.bulkSet(settings);
+      res.json({ data: { saved: true } });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+/**
+ * POST /api/linear/test
+ * Test the Linear connection with current credentials.
+ */
+router.post('/test', async (_req: Request, res: Response, next: NextFunction) => {
+  try {
+    const result = await linearService.testConnection();
+    res.json({ data: result });
+  } catch (err) {
+    next(err);
+  }
+});
+
+/**
+ * GET /api/linear/teams
+ * List Linear teams for the authenticated user.
+ */
+router.get('/teams', async (_req: Request, res: Response, next: NextFunction) => {
+  try {
+    const teams = await linearService.listTeams();
+    res.json({ data: teams });
+  } catch (err) {
+    next(err);
+  }
+});
+
+/**
+ * GET /api/linear/projects
+ * List projects for the configured team.
+ */
+router.get('/projects', async (_req: Request, res: Response, next: NextFunction) => {
+  try {
+    const projects = await linearService.listProjects();
+    res.json({ data: projects });
+  } catch (err) {
+    next(err);
+  }
+});
+
+/**
+ * GET /api/linear/labels
+ * List labels for the configured team.
+ */
+router.get('/labels', async (_req: Request, res: Response, next: NextFunction) => {
+  try {
+    const labels = await linearService.listLabels();
+    res.json({ data: labels });
+  } catch (err) {
+    next(err);
+  }
+});
+
+/**
+ * GET /api/linear/states
+ * List workflow states for the configured team.
+ */
+router.get('/states', async (_req: Request, res: Response, next: NextFunction) => {
+  try {
+    const states = await linearService.listStates();
+    res.json({ data: states });
+  } catch (err) {
+    next(err);
+  }
+});
+
+/**
+ * GET /api/linear/cycles
+ * List active cycles (sprints) for the configured team.
+ */
+router.get('/cycles', async (_req: Request, res: Response, next: NextFunction) => {
+  try {
+    const cycles = await linearService.listCycles();
+    res.json({ data: cycles });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// ─── Export & Sync ────────────────────────────────────────
+
+/**
+ * POST /api/linear/export/:proposalId
+ * Export a proposal to Linear as a new issue.
+ */
+router.post('/export/:proposalId', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const result = await linearService.exportProposal(req.params.proposalId);
+
+    await activityService.log({
+      type: 'linear_export',
+      description: `Exported proposal to Linear issue ${result.identifier}`,
+      metadata: { proposalId: req.params.proposalId, identifier: result.identifier },
+    });
+
+    res.status(201).json({ data: result });
+  } catch (err) {
+    if (err instanceof AppError) {
+      res.status(err.statusCode).json({ error: err.message, code: err.code });
+      return;
+    }
+    next(err);
+  }
+});
+
+/**
+ * POST /api/linear/sync/:proposalId
+ * Sync the Linear issue status back to the local record.
+ */
+router.post('/sync/:proposalId', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const result = await linearService.syncStatus(req.params.proposalId);
+    res.json({ data: result });
+  } catch (err) {
+    if (err instanceof AppError) {
+      res.status(err.statusCode).json({ error: err.message, code: err.code });
+      return;
+    }
+    next(err);
+  }
+});
+
+/**
+ * GET /api/linear/issues
+ * List all exported Linear issues.
+ */
+router.get('/issues', async (_req: Request, res: Response, next: NextFunction) => {
+  try {
+    const issues = await linearService.listExported();
+    res.json({ data: issues });
+  } catch (err) {
+    next(err);
+  }
+});
+
+/**
+ * GET /api/linear/issues/:proposalId
+ * Get the Linear issue linked to a specific proposal.
+ */
+router.get('/issues/:proposalId', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const issue = await linearService.getByProposal(req.params.proposalId);
+    res.json({ data: issue });
+  } catch (err) {
+    next(err);
+  }
+});
+
+/**
+ * DELETE /api/linear/issues/:proposalId
+ * Unlink a Linear issue from a proposal (does not delete the Linear issue itself).
+ */
+router.delete('/issues/:proposalId', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    await linearService.unlink(req.params.proposalId);
+    res.status(204).send();
+  } catch (err) {
+    if (err instanceof AppError) {
+      res.status(err.statusCode).json({ error: err.message, code: err.code });
+      return;
+    }
+    next(err);
+  }
+});
+
+// ─── Theme → Project Bulk Export ──────────────────────────
+
+/**
+ * POST /api/linear/export-theme/:themeId
+ * Export a theme as a Linear project with all proposals as issues.
+ */
+router.post('/export-theme/:themeId', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const result = await linearService.exportThemeAsProject(req.params.themeId);
+
+    await activityService.log({
+      type: 'linear_export',
+      description: `Exported theme as Linear project "${result.projectName}" with ${result.issuesCreated} issues`,
+      metadata: {
+        themeId: req.params.themeId,
+        projectName: result.projectName,
+        issuesCreated: result.issuesCreated,
+        issuesSkipped: result.issuesSkipped,
+      },
+    });
+
+    res.status(201).json({ data: result });
+  } catch (err) {
+    if (err instanceof AppError) {
+      res.status(err.statusCode).json({ error: err.message, code: err.code });
+      return;
+    }
+    next(err);
+  }
+});
+
+// ─── Spec Attachment ──────────────────────────────────────
+
+/**
+ * POST /api/linear/attach-spec/:proposalId
+ * Attach the generated PRD spec as a comment on the linked Linear issue.
+ */
+router.post('/attach-spec/:proposalId', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const result = await linearService.attachSpec(req.params.proposalId);
+    res.json({ data: result });
+  } catch (err) {
+    if (err instanceof AppError) {
+      res.status(err.statusCode).json({ error: err.message, code: err.code });
+      return;
+    }
+    next(err);
+  }
+});
+
+// ─── Feedback Import from Linear ──────────────────────────
+
+/**
+ * POST /api/linear/import-feedback
+ * Import issues from a Linear team/project as feedback items.
+ */
+router.post(
+  '/import-feedback',
+  validate(linearImportSchema, 'body'),
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { projectId, stateType, maxResults } = req.body as {
+        projectId?: string;
+        stateType?: string;
+        maxResults?: number;
+      };
+      const result = await linearService.importFeedbackFromLinear({
+        projectId,
+        stateType,
+        maxResults,
+      });
+
+      await activityService.log({
+        type: 'import',
+        description: `Imported ${result.imported} items from Linear (${result.skipped} skipped)`,
+        metadata: { source: 'linear', imported: result.imported, skipped: result.skipped },
+      });
+
+      res.status(201).json({ data: result });
+    } catch (err) {
+      if (err instanceof AppError) {
+        res.status(err.statusCode).json({ error: err.message, code: err.code });
+        return;
+      }
+      next(err);
+    }
+  },
+);
+
+// ─── Bulk Sync ────────────────────────────────────────────
+
+/**
+ * POST /api/linear/sync-all
+ * Sync status for all linked Linear issues. Auto-ships proposals
+ * when Linear issue moves to a "completed" state.
+ */
+router.post('/sync-all', async (_req: Request, res: Response, next: NextFunction) => {
+  try {
+    const result = await linearService.syncAllStatuses();
+
+    if (result.autoShipped > 0) {
+      await activityService.log({
+        type: 'linear_export',
+        description: `Linear sync: ${result.synced} synced, ${result.autoShipped} auto-shipped`,
+        metadata: result,
+      });
+    }
+
+    res.json({ data: result });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// ─── Linear Webhook Receiver ─────────────────────────────
+
+/**
+ * POST /api/linear/webhook
+ * Receive Linear webhook events for real-time issue status sync.
+ * Verifies HMAC-SHA256 signature when a webhook secret is configured.
+ */
+router.post(
+  '/webhook',
+  express.raw({ type: 'application/json' }),
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      // Parse the raw body
+      const rawBody = Buffer.isBuffer(req.body) ? req.body : Buffer.from(JSON.stringify(req.body));
+      const payload = Buffer.isBuffer(req.body) ? JSON.parse(rawBody.toString('utf-8')) : req.body;
+
+      // Verify signature if webhook secret is configured
+      const webhookSecret = await settingsService.getRaw(LINEAR_SETTING_KEYS.LINEAR_WEBHOOK_SECRET);
+      if (webhookSecret) {
+        const signature = req.headers['linear-signature'] as string | undefined;
+        if (!signature || !verifyWebhookSignature(rawBody, signature, webhookSecret)) {
+          logger.warn('Linear webhook rejected: invalid signature');
+          res.status(401).json({ error: 'Invalid webhook signature' });
+          return;
+        }
+
+        // Replay protection: reject timestamps older than 60 seconds
+        if (payload.webhookTimestamp) {
+          const age = Date.now() - payload.webhookTimestamp;
+          if (age > 60_000) {
+            logger.warn(`Linear webhook rejected: timestamp too old (${age}ms)`);
+            res.status(401).json({ error: 'Webhook timestamp expired' });
+            return;
+          }
+        }
+      }
+
+      const result = await linearService.handleWebhook(payload);
+      res.json({ data: result });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+// ─── Attachment ───────────────────────────────────────────
+
+/**
+ * POST /api/linear/attach/:proposalId
+ * Create a rich ShipScope attachment on the linked Linear issue.
+ */
+router.post('/attach/:proposalId', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const appBaseUrl =
+      (req.body as { appBaseUrl?: string })?.appBaseUrl ||
+      `${req.protocol}://${req.get('host') || 'localhost'}`;
+    const result = await linearService.createAttachment(req.params.proposalId, appBaseUrl);
+    res.status(201).json({ data: result });
+  } catch (err) {
+    if (err instanceof AppError) {
+      res.status(err.statusCode).json({ error: err.message, code: err.code });
+      return;
+    }
+    next(err);
+  }
+});
+
+// ─── Webhook Registration ─────────────────────────────────
+
+/**
+ * POST /api/linear/register-webhook
+ * Programmatically register a Linear webhook for real-time sync.
+ */
+router.post('/register-webhook', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { callbackUrl } = req.body as { callbackUrl: string };
+    if (!callbackUrl) {
+      res.status(400).json({ error: 'callbackUrl is required' });
+      return;
+    }
+    const result = await linearService.registerWebhook(callbackUrl);
+
+    await activityService.log({
+      type: 'linear_export',
+      description: `Registered Linear webhook for real-time sync`,
+      metadata: { webhookId: result.webhookId },
+    });
+
+    res.status(201).json({ data: result });
+  } catch (err) {
+    if (err instanceof AppError) {
+      res.status(err.statusCode).json({ error: err.message, code: err.code });
+      return;
+    }
+    next(err);
+  }
+});
+
+/**
+ * DELETE /api/linear/register-webhook
+ * Unregister the currently registered Linear webhook.
+ */
+router.delete('/register-webhook', async (_req: Request, res: Response, next: NextFunction) => {
+  try {
+    await linearService.unregisterWebhook();
+
+    await activityService.log({
+      type: 'linear_export',
+      description: `Unregistered Linear webhook`,
+    });
+
+    res.status(204).send();
+  } catch (err) {
+    if (err instanceof AppError) {
+      res.status(err.statusCode).json({ error: err.message, code: err.code });
+      return;
+    }
+    next(err);
+  }
+});
+
+// ─── Dashboard Summary ───────────────────────────────────
+
+/**
+ * GET /api/linear/dashboard
+ * Get Linear integration summary for the dashboard widget.
+ */
+router.get('/dashboard', async (_req: Request, res: Response, next: NextFunction) => {
+  try {
+    const summary = await linearService.getDashboardSummary();
+    res.json({ data: summary });
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/packages/api/src/schemas/linear.schema.ts
+++ b/packages/api/src/schemas/linear.schema.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+
+export const linearConfigSchema = z.object({
+  linear_api_key: z.string().min(1, 'Linear API key is required').optional(),
+  linear_team_id: z.string().min(1).optional(),
+  linear_project_id: z.string().min(1).optional(),
+  linear_done_states: z.string().max(500).optional(),
+  linear_default_label_id: z.string().min(1).optional(),
+  linear_cycle_id: z.string().min(1).optional(),
+  linear_webhook_secret: z.string().optional(),
+});
+
+export const linearImportSchema = z.object({
+  projectId: z.string().min(1).optional(),
+  stateType: z.enum(['backlog', 'unstarted', 'started', 'completed', 'cancelled']).optional(),
+  maxResults: z.number().int().min(1).max(100).optional(),
+});

--- a/packages/api/src/services/activity.service.ts
+++ b/packages/api/src/services/activity.service.ts
@@ -7,7 +7,8 @@ export type ActivityType =
   | 'proposal_generation'
   | 'spec_generation'
   | 'jira_export'
-  | 'trello_export';
+  | 'trello_export'
+  | 'linear_export';
 
 interface LogActivityInput {
   type: ActivityType;

--- a/packages/api/src/services/linear.service.ts
+++ b/packages/api/src/services/linear.service.ts
@@ -1,0 +1,1383 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import { prisma } from '../lib/prisma';
+import { NotFound, BadRequest } from '../lib/errors';
+import { logger } from '../lib/logger';
+import { settingsService } from './settings.service';
+
+// ─── Setting Keys ─────────────────────────────────────────
+
+export const LINEAR_SETTING_KEYS = {
+  LINEAR_API_KEY: 'linear_api_key',
+  LINEAR_TEAM_ID: 'linear_team_id',
+  LINEAR_PROJECT_ID: 'linear_project_id',
+  LINEAR_DONE_STATES: 'linear_done_states',
+  LINEAR_DEFAULT_LABEL_ID: 'linear_default_label_id',
+  LINEAR_CYCLE_ID: 'linear_cycle_id',
+  LINEAR_WEBHOOK_SECRET: 'linear_webhook_secret',
+  LINEAR_WEBHOOK_ID: 'linear_webhook_id',
+} as const;
+
+// ─── Types ────────────────────────────────────────────────
+
+interface LinearConfig {
+  apiKey: string;
+  teamId: string;
+  projectId: string;
+  doneStates: string[];
+  defaultLabelId: string;
+  cycleId: string;
+  webhookSecret: string;
+  webhookId: string;
+}
+
+interface LinearTeam {
+  id: string;
+  name: string;
+  key: string;
+}
+
+interface LinearProject {
+  id: string;
+  name: string;
+  url: string;
+  state: string;
+}
+
+interface LinearLabel {
+  id: string;
+  name: string;
+  color: string;
+}
+
+interface LinearCycle {
+  id: string;
+  name: string | null;
+  number: number;
+  startsAt: string;
+  endsAt: string;
+}
+
+interface LinearState {
+  id: string;
+  name: string;
+  type: string; // backlog, unstarted, started, completed, cancelled
+  color: string;
+}
+
+interface LinearIssueResponse {
+  id: string;
+  identifier: string;
+  title: string;
+  url: string;
+  priority: number;
+  estimate: number | null;
+  state: { id: string; name: string; type: string };
+  team: { id: string; key: string };
+  project: { id: string; name: string } | null;
+  labels: { nodes: { id: string; name: string }[] };
+}
+
+// ─── RICE tier helpers ────────────────────────────────────
+
+function getRiceTier(riceScore: number | null): { label: string; color: string } {
+  if (riceScore === null) return { label: 'Unscored', color: '#94A3B8' };
+  if (riceScore >= 8) return { label: 'High Priority', color: '#EF4444' };
+  if (riceScore >= 4) return { label: 'Medium Priority', color: '#F59E0B' };
+  return { label: 'Low Priority', color: '#22C55E' };
+}
+
+function riceToPriority(riceScore: number | null): number {
+  if (riceScore === null) return 0; // No priority
+  if (riceScore >= 8) return 1; // Urgent
+  if (riceScore >= 5) return 2; // High
+  if (riceScore >= 3) return 3; // Medium
+  return 4; // Low
+}
+
+function effortToEstimate(effortScore: number | null): number | null {
+  if (effortScore === null) return null;
+  // Map 1-10 effort → fibonacci estimates (1, 2, 3, 5, 8, 13, 21)
+  const map: Record<number, number> = {
+    1: 1,
+    2: 1,
+    3: 2,
+    4: 3,
+    5: 5,
+    6: 5,
+    7: 8,
+    8: 13,
+    9: 21,
+    10: 21,
+  };
+  return map[effortScore] ?? null;
+}
+
+// ─── Default done states ──────────────────────────────────
+
+const DEFAULT_DONE_STATES = ['done', 'completed', 'closed', 'shipped', 'released', 'cancelled'];
+
+// ─── Helpers ──────────────────────────────────────────────
+
+async function getLinearConfig(): Promise<LinearConfig> {
+  const [apiKey, teamId, projectId, doneStates, defaultLabelId, cycleId, webhookSecret, webhookId] =
+    await Promise.all([
+      settingsService.getRaw(LINEAR_SETTING_KEYS.LINEAR_API_KEY),
+      settingsService.getRaw(LINEAR_SETTING_KEYS.LINEAR_TEAM_ID),
+      settingsService.getRaw(LINEAR_SETTING_KEYS.LINEAR_PROJECT_ID),
+      settingsService.getRaw(LINEAR_SETTING_KEYS.LINEAR_DONE_STATES),
+      settingsService.getRaw(LINEAR_SETTING_KEYS.LINEAR_DEFAULT_LABEL_ID),
+      settingsService.getRaw(LINEAR_SETTING_KEYS.LINEAR_CYCLE_ID),
+      settingsService.getRaw(LINEAR_SETTING_KEYS.LINEAR_WEBHOOK_SECRET),
+      settingsService.getRaw(LINEAR_SETTING_KEYS.LINEAR_WEBHOOK_ID),
+    ]);
+
+  if (!apiKey) {
+    throw BadRequest('Linear is not configured. Please set your API key in settings.');
+  }
+
+  const parsedDoneStates = doneStates
+    ? doneStates
+        .split(',')
+        .map((s) => s.trim().toLowerCase())
+        .filter(Boolean)
+    : DEFAULT_DONE_STATES;
+
+  return {
+    apiKey,
+    teamId: teamId || '',
+    projectId: projectId || '',
+    doneStates: parsedDoneStates,
+    defaultLabelId: defaultLabelId || '',
+    cycleId: cycleId || '',
+    webhookSecret: webhookSecret || '',
+    webhookId: webhookId || '',
+  };
+}
+
+async function linearGraphQL<T>(
+  config: LinearConfig,
+  query: string,
+  variables: Record<string, unknown> = {},
+): Promise<T> {
+  const response = await fetch('https://api.linear.app/graphql', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: config.apiKey,
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    logger.error(`Linear API error [${response.status}]: ${body}`);
+    throw BadRequest(`Linear API error (${response.status}): ${body}`);
+  }
+
+  const json = (await response.json()) as { data?: T; errors?: { message: string }[] };
+
+  if (json.errors && json.errors.length > 0) {
+    const msg = json.errors.map((e) => e.message).join('; ');
+    logger.error(`Linear GraphQL errors: ${msg}`);
+    throw BadRequest(`Linear API error: ${msg}`);
+  }
+
+  return json.data as T;
+}
+
+// ─── Webhook Signature Verification ───────────────────────
+
+/**
+ * Verify Linear webhook signature using HMAC-SHA256.
+ * Linear sends the signature in the `linear-signature` header.
+ * Also checks `webhookTimestamp` for replay protection (60s window).
+ */
+export function verifyWebhookSignature(
+  rawBody: Buffer,
+  signature: string,
+  secret: string,
+): boolean {
+  if (!signature || !secret) return false;
+  const expected = createHmac('sha256', secret).update(rawBody).digest('hex');
+  try {
+    return timingSafeEqual(Buffer.from(signature, 'hex'), Buffer.from(expected, 'hex'));
+  } catch {
+    return false;
+  }
+}
+
+// ─── Service ──────────────────────────────────────────────
+
+export const linearService = {
+  /**
+   * Test the Linear connection with current credentials.
+   */
+  async testConnection(): Promise<{ success: boolean; message: string; userName?: string }> {
+    try {
+      const config = await getLinearConfig();
+      const data = await linearGraphQL<{
+        viewer: { id: string; name: string; email: string };
+      }>(config, `query { viewer { id name email } }`);
+      return {
+        success: true,
+        message: `Connected as ${data.viewer.name} (${data.viewer.email})`,
+        userName: data.viewer.name,
+      };
+    } catch (err) {
+      return {
+        success: false,
+        message: err instanceof Error ? err.message : 'Unknown error connecting to Linear',
+      };
+    }
+  },
+
+  /**
+   * List teams the authenticated user belongs to.
+   */
+  async listTeams(): Promise<LinearTeam[]> {
+    const config = await getLinearConfig();
+    const data = await linearGraphQL<{
+      teams: { nodes: LinearTeam[] };
+    }>(config, `query { teams { nodes { id name key } } }`);
+    return data.teams.nodes;
+  },
+
+  /**
+   * List projects for the configured team.
+   */
+  async listProjects(): Promise<LinearProject[]> {
+    const config = await getLinearConfig();
+    if (!config.teamId) throw BadRequest('No Linear team configured');
+    const data = await linearGraphQL<{
+      team: { projects: { nodes: LinearProject[] } };
+    }>(
+      config,
+      `query($teamId: String!) {
+        team(id: $teamId) {
+          projects(filter: { state: { in: ["planned", "started", "paused"] } }) {
+            nodes { id name url state }
+          }
+        }
+      }`,
+      { teamId: config.teamId },
+    );
+    return data.team.projects.nodes;
+  },
+
+  /**
+   * List labels for the configured team.
+   */
+  async listLabels(): Promise<LinearLabel[]> {
+    const config = await getLinearConfig();
+    if (!config.teamId) throw BadRequest('No Linear team configured');
+    const data = await linearGraphQL<{
+      team: { labels: { nodes: LinearLabel[] } };
+    }>(
+      config,
+      `query($teamId: String!) {
+        team(id: $teamId) {
+          labels { nodes { id name color } }
+        }
+      }`,
+      { teamId: config.teamId },
+    );
+    return data.team.labels.nodes;
+  },
+
+  /**
+   * List workflow states for the configured team.
+   */
+  async listStates(): Promise<LinearState[]> {
+    const config = await getLinearConfig();
+    if (!config.teamId) throw BadRequest('No Linear team configured');
+    const data = await linearGraphQL<{
+      team: { states: { nodes: LinearState[] } };
+    }>(
+      config,
+      `query($teamId: String!) {
+        team(id: $teamId) {
+          states { nodes { id name type color } }
+        }
+      }`,
+      { teamId: config.teamId },
+    );
+    return data.team.states.nodes;
+  },
+
+  /**
+   * List active cycles (sprints) for the configured team.
+   */
+  async listCycles(): Promise<LinearCycle[]> {
+    const config = await getLinearConfig();
+    if (!config.teamId) throw BadRequest('No Linear team configured');
+    const data = await linearGraphQL<{
+      team: { cycles: { nodes: LinearCycle[] } };
+    }>(
+      config,
+      `query($teamId: String!) {
+        team(id: $teamId) {
+          cycles(filter: { isActive: { eq: true } }) {
+            nodes { id name number startsAt endsAt }
+          }
+        }
+      }`,
+      { teamId: config.teamId },
+    );
+    return data.team.cycles.nodes;
+  },
+
+  /**
+   * Export a proposal to Linear as a new issue.
+   */
+  async exportProposal(proposalId: string): Promise<{
+    id: string;
+    identifier: string;
+    linearUrl: string;
+  }> {
+    const config = await getLinearConfig();
+
+    if (!config.teamId) {
+      throw BadRequest('No Linear team configured. Select a team in settings.');
+    }
+
+    // Check if already exported
+    const existing = await prisma.linearIssue.findUnique({ where: { proposalId } });
+    if (existing) {
+      throw BadRequest(`Proposal already exported to Linear as ${existing.identifier}`);
+    }
+
+    // Get proposal with evidence
+    const proposal = await prisma.proposal.findUnique({
+      where: { id: proposalId },
+      include: {
+        theme: { select: { name: true, category: true } },
+        evidence: {
+          take: 10,
+          orderBy: { relevanceScore: 'desc' },
+          include: {
+            feedbackItem: { select: { content: true, author: true, channel: true } },
+          },
+        },
+      },
+    });
+
+    if (!proposal) throw NotFound('Proposal');
+
+    // Build description in Linear's markdown format
+    const description = buildLinearDescription(proposal);
+
+    // Map RICE to Linear priority (0=No, 1=Urgent, 2=High, 3=Medium, 4=Low)
+    const priority = riceToPriority(proposal.riceScore);
+    const estimate = effortToEstimate(proposal.effortScore);
+
+    // Get or create RICE tier label
+    const riceTier = getRiceTier(proposal.riceScore);
+    const labelId = await getOrCreateLabel(config, riceTier.label, riceTier.color);
+
+    // Build label IDs
+    const labelIds: string[] = [];
+    if (labelId) labelIds.push(labelId);
+    if (config.defaultLabelId) labelIds.push(config.defaultLabelId);
+
+    // Category label
+    if (proposal.theme?.category) {
+      const catLabel = await getOrCreateLabel(
+        config,
+        formatCategory(proposal.theme.category),
+        getCategoryColor(proposal.theme.category),
+      );
+      if (catLabel) labelIds.push(catLabel);
+    }
+
+    // Build mutation input
+    const input: Record<string, unknown> = {
+      teamId: config.teamId,
+      title: proposal.title,
+      description,
+      priority,
+      labelIds: [...new Set(labelIds)],
+    };
+
+    if (estimate !== null) input.estimate = estimate;
+    if (config.projectId) input.projectId = config.projectId;
+    if (config.cycleId) input.cycleId = config.cycleId;
+
+    const data = await linearGraphQL<{
+      issueCreate: {
+        success: boolean;
+        issue: LinearIssueResponse;
+      };
+    }>(
+      config,
+      `mutation($input: IssueCreateInput!) {
+        issueCreate(input: $input) {
+          success
+          issue {
+            id identifier title url priority estimate
+            state { id name type }
+            team { id key }
+            project { id name }
+            labels { nodes { id name } }
+          }
+        }
+      }`,
+      { input },
+    );
+
+    if (!data.issueCreate.success) {
+      throw BadRequest('Failed to create Linear issue');
+    }
+
+    const issue = data.issueCreate.issue;
+
+    // Store the link in our database
+    const linearIssue = await prisma.linearIssue.create({
+      data: {
+        proposalId,
+        linearId: issue.id,
+        identifier: issue.identifier,
+        linearUrl: issue.url,
+        teamId: config.teamId,
+        status: issue.state.name,
+        priority: issue.priority,
+        issueTitle: proposal.title,
+        projectId: issue.project?.id || null,
+        projectName: issue.project?.name || null,
+        labelIds: labelIds,
+        cycleId: config.cycleId || null,
+        estimate: estimate,
+      },
+    });
+
+    logger.info(`Exported proposal ${proposalId} to Linear as ${issue.identifier}`);
+
+    return {
+      id: linearIssue.id,
+      identifier: issue.identifier,
+      linearUrl: issue.url,
+    };
+  },
+
+  /**
+   * Sync the status of a Linear issue back to the local record.
+   */
+  async syncStatus(
+    proposalId: string,
+  ): Promise<{ identifier: string; status: string; titleUpdated: boolean }> {
+    const config = await getLinearConfig();
+    const linearIssue = await prisma.linearIssue.findUnique({ where: { proposalId } });
+    if (!linearIssue) throw NotFound('Linear issue for this proposal');
+
+    const data = await linearGraphQL<{
+      issue: LinearIssueResponse;
+    }>(
+      config,
+      `query($id: String!) {
+        issue(id: $id) {
+          id identifier title url priority estimate
+          state { id name type }
+          team { id key }
+          project { id name }
+          labels { nodes { id name } }
+        }
+      }`,
+      { id: linearIssue.linearId },
+    );
+
+    const issue = data.issue;
+
+    // Two-way title sync
+    let titleUpdated = false;
+    if (issue.title !== linearIssue.issueTitle) {
+      await prisma.proposal.update({
+        where: { id: proposalId },
+        data: { title: issue.title },
+      });
+      titleUpdated = true;
+      logger.info(`Synced title from Linear issue to proposal ${proposalId}: "${issue.title}"`);
+    }
+
+    await prisma.linearIssue.update({
+      where: { proposalId },
+      data: {
+        status: issue.state.name,
+        priority: issue.priority,
+        issueTitle: issue.title,
+        estimate: issue.estimate,
+        projectId: issue.project?.id || null,
+        projectName: issue.project?.name || null,
+        syncedAt: new Date(),
+      },
+    });
+
+    // Auto-ship if state type is "completed"
+    if (
+      issue.state.type === 'completed' ||
+      config.doneStates.includes(issue.state.name.toLowerCase())
+    ) {
+      const proposal = await prisma.proposal.findUnique({
+        where: { id: proposalId },
+        select: { status: true },
+      });
+      if (proposal && proposal.status !== 'shipped') {
+        await prisma.proposal.update({
+          where: { id: proposalId },
+          data: { status: 'shipped' },
+        });
+        logger.info(
+          `Auto-shipped proposal ${proposalId} (Linear issue state: "${issue.state.name}")`,
+        );
+      }
+    }
+
+    return { identifier: linearIssue.identifier, status: issue.state.name, titleUpdated };
+  },
+
+  /**
+   * Get the Linear issue linked to a proposal (if any).
+   */
+  async getByProposal(proposalId: string) {
+    return prisma.linearIssue.findUnique({ where: { proposalId } });
+  },
+
+  /**
+   * List all exported Linear issues.
+   */
+  async listExported() {
+    return prisma.linearIssue.findMany({
+      include: {
+        proposal: { select: { id: true, title: true, status: true, riceScore: true } },
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+  },
+
+  /**
+   * Unlink a Linear issue from a proposal (does not delete the Linear issue).
+   */
+  async unlink(proposalId: string): Promise<void> {
+    const linearIssue = await prisma.linearIssue.findUnique({ where: { proposalId } });
+    if (!linearIssue) throw NotFound('Linear issue link for this proposal');
+    await prisma.linearIssue.delete({ where: { proposalId } });
+    logger.info(`Unlinked Linear issue ${linearIssue.identifier} from proposal ${proposalId}`);
+  },
+
+  /**
+   * Export all proposals under a theme as Linear issues in a dedicated project.
+   */
+  async exportThemeAsProject(themeId: string): Promise<{
+    projectName: string;
+    projectUrl: string;
+    issuesCreated: number;
+    issuesSkipped: number;
+  }> {
+    const config = await getLinearConfig();
+    if (!config.teamId) throw BadRequest('No Linear team configured');
+
+    const theme = await prisma.theme.findUnique({
+      where: { id: themeId },
+      include: {
+        proposals: {
+          include: {
+            theme: { select: { name: true, category: true } },
+            linearIssue: true,
+            evidence: {
+              take: 5,
+              orderBy: { relevanceScore: 'desc' },
+              include: {
+                feedbackItem: { select: { content: true, author: true, channel: true } },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!theme) throw NotFound('Theme');
+
+    if (theme.linearProjectId) {
+      throw BadRequest(`Theme already exported to Linear project`);
+    }
+
+    // Create a new project for this theme
+    const projectData = await linearGraphQL<{
+      projectCreate: {
+        success: boolean;
+        project: { id: string; name: string; url: string };
+      };
+    }>(
+      config,
+      `mutation($input: ProjectCreateInput!) {
+        projectCreate(input: $input) {
+          success
+          project { id name url }
+        }
+      }`,
+      {
+        input: {
+          name: `[ShipScope] ${theme.name}`,
+          description: `Product theme: ${theme.description}\n\nCategory: ${theme.category || 'General'}\nFeedback count: ${theme.feedbackCount}\nOpportunity score: ${theme.opportunityScore.toFixed(1)}`,
+          teamIds: [config.teamId],
+        },
+      },
+    );
+
+    if (!projectData.projectCreate.success) {
+      throw BadRequest('Failed to create Linear project');
+    }
+
+    const project = projectData.projectCreate.project;
+
+    // Save project link on theme
+    await prisma.theme.update({
+      where: { id: themeId },
+      data: {
+        linearProjectId: project.id,
+        linearProjectUrl: project.url,
+      },
+    });
+
+    // Create issues for each proposal
+    let issuesCreated = 0;
+    let issuesSkipped = 0;
+
+    for (const proposal of theme.proposals) {
+      if (proposal.linearIssue) {
+        issuesSkipped++;
+        continue;
+      }
+
+      try {
+        const description = buildLinearDescription(proposal);
+        const priority = riceToPriority(proposal.riceScore);
+        const estimate = effortToEstimate(proposal.effortScore);
+
+        // Labels
+        const riceTier = getRiceTier(proposal.riceScore);
+        const labelId = await getOrCreateLabel(config, riceTier.label, riceTier.color);
+        const labelIds: string[] = [];
+        if (labelId) labelIds.push(labelId);
+
+        const input: Record<string, unknown> = {
+          teamId: config.teamId,
+          title: proposal.title,
+          description,
+          priority,
+          projectId: project.id,
+          labelIds,
+        };
+        if (estimate !== null) input.estimate = estimate;
+        if (config.cycleId) input.cycleId = config.cycleId;
+
+        const issueData = await linearGraphQL<{
+          issueCreate: {
+            success: boolean;
+            issue: LinearIssueResponse;
+          };
+        }>(
+          config,
+          `mutation($input: IssueCreateInput!) {
+            issueCreate(input: $input) {
+              success
+              issue {
+                id identifier title url priority estimate
+                state { id name type }
+                team { id key }
+                project { id name }
+                labels { nodes { id name } }
+              }
+            }
+          }`,
+          { input },
+        );
+
+        if (!issueData.issueCreate.success) {
+          issuesSkipped++;
+          continue;
+        }
+
+        const issue = issueData.issueCreate.issue;
+
+        await prisma.linearIssue.create({
+          data: {
+            proposalId: proposal.id,
+            linearId: issue.id,
+            identifier: issue.identifier,
+            linearUrl: issue.url,
+            teamId: config.teamId,
+            status: issue.state.name,
+            priority: issue.priority,
+            issueTitle: proposal.title,
+            projectId: project.id,
+            projectName: project.name,
+            labelIds,
+            estimate: estimate,
+          },
+        });
+
+        issuesCreated++;
+      } catch (err) {
+        logger.error(`Failed to create Linear issue for proposal ${proposal.id}: ${err}`);
+        issuesSkipped++;
+      }
+    }
+
+    logger.info(
+      `Exported theme ${themeId} as Linear project "${project.name}" with ${issuesCreated} issues`,
+    );
+
+    return {
+      projectName: project.name,
+      projectUrl: project.url,
+      issuesCreated,
+      issuesSkipped,
+    };
+  },
+
+  /**
+   * Attach the generated PRD spec as a comment on the linked Linear issue.
+   */
+  async attachSpec(proposalId: string): Promise<{ identifier: string; commented: boolean }> {
+    const config = await getLinearConfig();
+
+    const linearIssue = await prisma.linearIssue.findUnique({ where: { proposalId } });
+    if (!linearIssue) throw NotFound('No Linear issue linked to this proposal');
+
+    const spec = await prisma.spec.findUnique({ where: { proposalId } });
+    if (!spec || !spec.prdMarkdown) throw BadRequest('No spec generated for this proposal');
+
+    const commentBody = `## PRD Spec (v${spec.version}) — Generated by ShipScope\n\n${spec.prdMarkdown}`;
+
+    await linearGraphQL(
+      config,
+      `mutation($input: CommentCreateInput!) {
+        commentCreate(input: $input) { success }
+      }`,
+      {
+        input: {
+          issueId: linearIssue.linearId,
+          body: commentBody,
+        },
+      },
+    );
+
+    logger.info(`Attached spec v${spec.version} to Linear issue ${linearIssue.identifier}`);
+    return { identifier: linearIssue.identifier, commented: true };
+  },
+
+  /**
+   * Import issues from a Linear team/project as feedback items.
+   */
+  async importFeedbackFromLinear(
+    options: {
+      projectId?: string;
+      stateType?: string;
+      maxResults?: number;
+    } = {},
+  ): Promise<{ imported: number; skipped: number; sourceId: string }> {
+    const config = await getLinearConfig();
+    if (!config.teamId) throw BadRequest('No Linear team configured');
+
+    const maxResults = Math.min(options.maxResults || 50, 100);
+
+    // Build filter for issues query
+    const filterParts: string[] = [];
+    if (options.projectId) {
+      filterParts.push(`project: { id: { eq: "${options.projectId}" } }`);
+    }
+    if (options.stateType) {
+      filterParts.push(`state: { type: { eq: "${options.stateType}" } }`);
+    }
+    const filterArg = filterParts.length > 0 ? `, filter: { ${filterParts.join(', ')} }` : '';
+
+    const data = await linearGraphQL<{
+      team: {
+        issues: {
+          nodes: {
+            id: string;
+            identifier: string;
+            title: string;
+            description: string | null;
+            url: string;
+            priority: number;
+            state: { name: string; type: string };
+            assignee: { name: string } | null;
+          }[];
+        };
+      };
+    }>(
+      config,
+      `query($teamId: String!, $first: Int!) {
+        team(id: $teamId) {
+          issues(first: $first${filterArg}) {
+            nodes {
+              id identifier title description url priority
+              state { name type }
+              assignee { name }
+            }
+          }
+        }
+      }`,
+      { teamId: config.teamId, first: maxResults },
+    );
+
+    // Create a feedback source for this import
+    const source = await prisma.feedbackSource.create({
+      data: {
+        name: `Linear Import (${config.teamId})`,
+        type: 'linear',
+        metadata: {
+          teamId: config.teamId,
+          projectId: options.projectId || null,
+          importedAt: new Date().toISOString(),
+        },
+      },
+    });
+
+    let imported = 0;
+    let skipped = 0;
+
+    for (const issue of data.team.issues.nodes) {
+      // Skip if already imported
+      const existing = await prisma.feedbackItem.findFirst({
+        where: {
+          metadata: { path: ['linear_id'], equals: issue.id },
+        },
+      });
+
+      if (existing) {
+        skipped++;
+        continue;
+      }
+
+      const content = issue.description
+        ? `[${issue.identifier}] ${issue.title}: ${issue.description}`
+        : `[${issue.identifier}] ${issue.title}`;
+
+      await prisma.feedbackItem.create({
+        data: {
+          content: content.slice(0, 5000),
+          sourceId: source.id,
+          author: issue.assignee?.name || null,
+          channel: `linear_${issue.state.type}`,
+          metadata: {
+            linear_id: issue.id,
+            linear_identifier: issue.identifier,
+            linear_url: issue.url,
+            linear_status: issue.state.name,
+            linear_priority: issue.priority,
+          },
+        },
+      });
+      imported++;
+    }
+
+    // Update source row count
+    await prisma.feedbackSource.update({
+      where: { id: source.id },
+      data: { rowCount: imported },
+    });
+
+    return { imported, skipped, sourceId: source.id };
+  },
+
+  /**
+   * Sync status for ALL linked Linear issues. Auto-updates proposal
+   * status when an issue moves to a "completed" state.
+   */
+  async syncAllStatuses(): Promise<{
+    synced: number;
+    autoShipped: number;
+    errors: number;
+  }> {
+    const config = await getLinearConfig();
+    const allIssues = await prisma.linearIssue.findMany({
+      include: { proposal: { select: { id: true, status: true } } },
+    });
+
+    let synced = 0;
+    let autoShipped = 0;
+    let errors = 0;
+
+    for (const linearIssue of allIssues) {
+      try {
+        const data = await linearGraphQL<{
+          issue: {
+            id: string;
+            identifier: string;
+            title: string;
+            url: string;
+            priority: number;
+            estimate: number | null;
+            state: { id: string; name: string; type: string };
+          };
+        }>(
+          config,
+          `query($id: String!) {
+            issue(id: $id) {
+              id identifier title url priority estimate
+              state { id name type }
+            }
+          }`,
+          { id: linearIssue.linearId },
+        );
+
+        const issue = data.issue;
+
+        await prisma.linearIssue.update({
+          where: { id: linearIssue.id },
+          data: {
+            status: issue.state.name,
+            priority: issue.priority,
+            issueTitle: issue.title,
+            estimate: issue.estimate,
+            syncedAt: new Date(),
+          },
+        });
+
+        // Auto-mark proposal as "shipped" when state is completed
+        const isDone =
+          issue.state.type === 'completed' ||
+          config.doneStates.includes(issue.state.name.toLowerCase());
+
+        if (isDone && linearIssue.proposal.status !== 'shipped') {
+          await prisma.proposal.update({
+            where: { id: linearIssue.proposal.id },
+            data: { status: 'shipped' },
+          });
+          autoShipped++;
+          logger.info(
+            `Auto-shipped proposal ${linearIssue.proposal.id} (Linear issue state: "${issue.state.name}")`,
+          );
+        }
+
+        synced++;
+      } catch (err) {
+        logger.error(`Failed to sync Linear issue ${linearIssue.identifier}: ${err}`);
+        errors++;
+      }
+    }
+
+    return { synced, autoShipped, errors };
+  },
+
+  /**
+   * Handle incoming Linear webhook events for real-time sync.
+   * Linear webhooks send JSON with type, action, data, and url fields.
+   */
+  async handleWebhook(payload: {
+    type?: string;
+    action?: string;
+    data?: {
+      id?: string;
+      identifier?: string;
+      title?: string;
+      state?: { id: string; name: string; type: string };
+      priority?: number;
+    };
+    url?: string;
+  }): Promise<{ processed: boolean; identifier?: string }> {
+    // Only process Issue updates
+    if (payload.type !== 'Issue' || !payload.data?.id) {
+      return { processed: false };
+    }
+
+    const linearId = payload.data.id;
+    const linearIssue = await prisma.linearIssue.findUnique({ where: { linearId } });
+
+    if (!linearIssue) {
+      return { processed: false }; // Not tracked by us
+    }
+
+    const updateData: Record<string, unknown> = { syncedAt: new Date() };
+
+    if (payload.data.state?.name) {
+      updateData.status = payload.data.state.name;
+    }
+    if (payload.data.title) {
+      updateData.issueTitle = payload.data.title;
+    }
+    if (payload.data.priority !== undefined) {
+      updateData.priority = payload.data.priority;
+    }
+
+    await prisma.linearIssue.update({
+      where: { linearId },
+      data: updateData,
+    });
+
+    // Auto-ship proposal if state is completed
+    const stateType = payload.data.state?.type;
+    const stateName = payload.data.state?.name?.toLowerCase();
+    let doneStates: string[];
+    try {
+      const cfg = await getLinearConfig();
+      doneStates = cfg.doneStates;
+    } catch {
+      doneStates = DEFAULT_DONE_STATES;
+    }
+
+    if (stateType === 'completed' || (stateName && doneStates.includes(stateName))) {
+      const proposal = await prisma.proposal.findUnique({
+        where: { id: linearIssue.proposalId },
+        select: { status: true },
+      });
+      if (proposal && proposal.status !== 'shipped') {
+        await prisma.proposal.update({
+          where: { id: linearIssue.proposalId },
+          data: { status: 'shipped' },
+        });
+        logger.info(
+          `Webhook auto-shipped proposal ${linearIssue.proposalId} (Linear issue → "${payload.data.state?.name}")`,
+        );
+      }
+    }
+
+    return { processed: true, identifier: linearIssue.identifier };
+  },
+
+  /**
+   * Create a rich ShipScope attachment on a Linear issue (idempotent by URL).
+   */
+  async createAttachment(
+    proposalId: string,
+    appBaseUrl: string,
+  ): Promise<{ attachmentId: string }> {
+    const config = await getLinearConfig();
+
+    const linearIssue = await prisma.linearIssue.findUnique({ where: { proposalId } });
+    if (!linearIssue) throw NotFound('No Linear issue linked to this proposal');
+
+    const proposal = await prisma.proposal.findUnique({
+      where: { id: proposalId },
+      select: {
+        title: true,
+        riceScore: true,
+        status: true,
+        theme: { select: { name: true } },
+        _count: { select: { evidence: true } },
+      },
+    });
+    if (!proposal) throw NotFound('Proposal');
+
+    const riceTier = getRiceTier(proposal.riceScore);
+    const subtitle = [
+      `RICE: ${proposal.riceScore?.toFixed(1) ?? 'N/A'}`,
+      `Status: ${proposal.status}`,
+      proposal.theme ? `Theme: ${proposal.theme.name}` : null,
+      `${proposal._count.evidence} evidence items`,
+    ]
+      .filter(Boolean)
+      .join(' · ');
+
+    const url = `${appBaseUrl}/proposals/${proposalId}`;
+
+    const data = await linearGraphQL<{
+      attachmentCreate: { success: boolean; attachment: { id: string } };
+    }>(
+      config,
+      `mutation($input: AttachmentCreateInput!) {
+        attachmentCreate(input: $input) {
+          success
+          attachment { id }
+        }
+      }`,
+      {
+        input: {
+          issueId: linearIssue.linearId,
+          title: `ShipScope: ${proposal.title}`,
+          subtitle,
+          url,
+          iconUrl: `${appBaseUrl}/favicon.ico`,
+          metadata: {
+            messages: [
+              {
+                icon: 'signal',
+                color: riceTier.color,
+                message: `${riceTier.label} — RICE ${proposal.riceScore?.toFixed(1) ?? 'N/A'}`,
+              },
+            ],
+            attributes: [
+              { label: 'Status', value: proposal.status, type: 'string' },
+              { label: 'Evidence', value: String(proposal._count.evidence), type: 'string' },
+            ],
+          },
+        },
+      },
+    );
+
+    if (!data.attachmentCreate.success) {
+      throw BadRequest('Failed to create attachment on Linear issue');
+    }
+
+    logger.info(`Created ShipScope attachment on Linear issue ${linearIssue.identifier}`);
+    return { attachmentId: data.attachmentCreate.attachment.id };
+  },
+
+  /**
+   * Register a webhook programmatically via Linear's API.
+   * Stores the webhook ID in settings for future management.
+   */
+  async registerWebhook(callbackUrl: string): Promise<{ webhookId: string; enabled: boolean }> {
+    const config = await getLinearConfig();
+
+    if (config.webhookId) {
+      throw BadRequest('Webhook already registered. Unregister the existing one first.');
+    }
+
+    const data = await linearGraphQL<{
+      webhookCreate: {
+        success: boolean;
+        webhook: { id: string; enabled: boolean; secret: string };
+      };
+    }>(
+      config,
+      `mutation($input: WebhookCreateInput!) {
+        webhookCreate(input: $input) {
+          success
+          webhook { id enabled secret }
+        }
+      }`,
+      {
+        input: {
+          url: callbackUrl,
+          teamId: config.teamId || undefined,
+          allPublicTeams: !config.teamId,
+          resourceTypes: ['Issue', 'Comment', 'Project'],
+          label: 'ShipScope Integration',
+          enabled: true,
+        },
+      },
+    );
+
+    if (!data.webhookCreate.success) {
+      throw BadRequest('Failed to register Linear webhook');
+    }
+
+    const webhook = data.webhookCreate.webhook;
+
+    // Store webhook ID and secret in settings
+    await settingsService.bulkSet({
+      [LINEAR_SETTING_KEYS.LINEAR_WEBHOOK_ID]: webhook.id,
+      [LINEAR_SETTING_KEYS.LINEAR_WEBHOOK_SECRET]: webhook.secret,
+    });
+
+    logger.info(`Registered Linear webhook ${webhook.id}`);
+    return { webhookId: webhook.id, enabled: webhook.enabled };
+  },
+
+  /**
+   * Unregister the currently registered Linear webhook.
+   */
+  async unregisterWebhook(): Promise<void> {
+    const config = await getLinearConfig();
+
+    if (!config.webhookId) {
+      throw BadRequest('No webhook registered');
+    }
+
+    await linearGraphQL(
+      config,
+      `mutation($id: String!) {
+        webhookDelete(id: $id) { success }
+      }`,
+      { id: config.webhookId },
+    );
+
+    // Clear webhook settings
+    await settingsService.bulkSet({
+      [LINEAR_SETTING_KEYS.LINEAR_WEBHOOK_ID]: '',
+      [LINEAR_SETTING_KEYS.LINEAR_WEBHOOK_SECRET]: '',
+    });
+
+    logger.info(`Unregistered Linear webhook ${config.webhookId}`);
+  },
+
+  /**
+   * Get Linear sync summary for the dashboard widget.
+   */
+  async getDashboardSummary(): Promise<{
+    totalExported: number;
+    byStatus: Record<string, number>;
+    byPriority: Record<string, number>;
+    recentExports: {
+      identifier: string;
+      issueTitle: string;
+      status: string;
+      priority: number;
+      linearUrl: string;
+      createdAt: string;
+    }[];
+  }> {
+    const allIssues = await prisma.linearIssue.findMany({
+      select: {
+        identifier: true,
+        issueTitle: true,
+        status: true,
+        priority: true,
+        linearUrl: true,
+        createdAt: true,
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    const byStatus: Record<string, number> = {};
+    const byPriority: Record<string, number> = {};
+    const priorityNames = ['No Priority', 'Urgent', 'High', 'Medium', 'Low'];
+
+    for (const issue of allIssues) {
+      byStatus[issue.status] = (byStatus[issue.status] || 0) + 1;
+      const pName = priorityNames[issue.priority] || 'Unknown';
+      byPriority[pName] = (byPriority[pName] || 0) + 1;
+    }
+
+    return {
+      totalExported: allIssues.length,
+      byStatus,
+      byPriority,
+      recentExports: allIssues.slice(0, 5).map((i) => ({
+        ...i,
+        createdAt: i.createdAt.toISOString(),
+      })),
+    };
+  },
+};
+
+// ─── Helpers ──────────────────────────────────────────────
+
+interface ProposalWithEvidence {
+  title: string;
+  problem: string;
+  solution: string;
+  reachScore: number | null;
+  impactScore: number | null;
+  confidenceScore: number | null;
+  effortScore: number | null;
+  riceScore: number | null;
+  theme: { name: string; category?: string | null } | null;
+  evidence: {
+    feedbackItem: { content: string; author: string | null; channel: string | null };
+  }[];
+}
+
+/**
+ * Build a Linear issue description in Markdown.
+ */
+function buildLinearDescription(proposal: ProposalWithEvidence): string {
+  const sections: string[] = [];
+
+  sections.push(`## Problem\n${proposal.problem}`);
+  sections.push(`## Solution\n${proposal.solution}`);
+
+  if (proposal.riceScore !== null) {
+    sections.push(
+      `## RICE Score\n` +
+        `| Metric | Score |\n|--------|-------|\n` +
+        `| Reach | ${proposal.reachScore ?? '-'} |\n` +
+        `| Impact | ${proposal.impactScore ?? '-'} |\n` +
+        `| Confidence | ${proposal.confidenceScore ?? '-'} |\n` +
+        `| Effort | ${proposal.effortScore ?? '-'} |\n` +
+        `| **Total** | **${proposal.riceScore?.toFixed(1) ?? '-'}** |`,
+    );
+  }
+
+  if (proposal.theme) {
+    sections.push(`## Theme\n${proposal.theme.name}`);
+  }
+
+  if (proposal.evidence.length > 0) {
+    const quotes = proposal.evidence
+      .map(
+        (ev) =>
+          `> ${ev.feedbackItem.content.slice(0, 200)}${ev.feedbackItem.author ? `\n> — ${ev.feedbackItem.author}` : ''}${ev.feedbackItem.channel ? ` *(${ev.feedbackItem.channel})*` : ''}`,
+      )
+      .join('\n\n');
+    sections.push(`## Customer Evidence\n${quotes}`);
+  }
+
+  sections.push(`---\n*Generated by ShipScope*`);
+
+  return sections.join('\n\n');
+}
+
+function formatCategory(category: string): string {
+  const labels: Record<string, string> = {
+    bug: 'Bug',
+    feature_request: 'Feature',
+    ux_issue: 'UX',
+    performance: 'Performance',
+    documentation: 'Documentation',
+    pricing: 'Pricing',
+  };
+  return labels[category] || category;
+}
+
+function getCategoryColor(category: string | null): string {
+  const colors: Record<string, string> = {
+    bug: '#EF4444',
+    feature_request: '#3B82F6',
+    ux_issue: '#A855F7',
+    performance: '#F97316',
+    documentation: '#84CC16',
+    pricing: '#EAB308',
+  };
+  return colors[category || ''] || '#94A3B8';
+}
+
+/**
+ * Get or create a Linear label on the configured team.
+ */
+async function getOrCreateLabel(
+  config: LinearConfig,
+  name: string,
+  color: string,
+): Promise<string | null> {
+  if (!config.teamId) return null;
+
+  try {
+    // Check existing labels
+    const data = await linearGraphQL<{
+      team: { labels: { nodes: { id: string; name: string }[] } };
+    }>(
+      config,
+      `query($teamId: String!) {
+        team(id: $teamId) {
+          labels { nodes { id name } }
+        }
+      }`,
+      { teamId: config.teamId },
+    );
+
+    const existing = data.team.labels.nodes.find(
+      (l) => l.name.toLowerCase() === name.toLowerCase(),
+    );
+    if (existing) return existing.id;
+
+    // Create new label
+    const created = await linearGraphQL<{
+      issueLabelCreate: {
+        success: boolean;
+        issueLabel: { id: string };
+      };
+    }>(
+      config,
+      `mutation($input: IssueLabelCreateInput!) {
+        issueLabelCreate(input: $input) {
+          success
+          issueLabel { id }
+        }
+      }`,
+      {
+        input: {
+          name,
+          color,
+          teamId: config.teamId,
+        },
+      },
+    );
+
+    return created.issueLabelCreate.success ? created.issueLabelCreate.issueLabel.id : null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/api/src/services/settings.service.ts
+++ b/packages/api/src/services/settings.service.ts
@@ -41,6 +41,16 @@ export const settingsService = {
       const token = result['trello_token'];
       result['trello_token'] = token.slice(0, 4) + '...' + token.slice(-4);
     }
+    // Mask the Linear API key
+    if (result['linear_api_key']) {
+      const key = result['linear_api_key'];
+      result['linear_api_key'] = key.slice(0, 6) + '...' + key.slice(-4);
+    }
+    // Mask the Linear webhook secret
+    if (result['linear_webhook_secret']) {
+      const s = result['linear_webhook_secret'];
+      result['linear_webhook_secret'] = s.slice(0, 4) + '...' + s.slice(-4);
+    }
     return result;
   },
 

--- a/packages/api/tests/helpers/factories.ts
+++ b/packages/api/tests/helpers/factories.ts
@@ -102,6 +102,22 @@ export async function createTrelloCard(proposalId: string, overrides = {}) {
   });
 }
 
+export async function createLinearIssue(proposalId: string, overrides = {}) {
+  return prisma.linearIssue.create({
+    data: {
+      proposalId,
+      linearId: 'lin-uuid-001',
+      identifier: 'ENG-1',
+      linearUrl: 'https://linear.app/team/issue/ENG-1',
+      teamId: 'team-001',
+      status: 'Backlog',
+      priority: 0,
+      issueTitle: 'Test Linear Issue',
+      ...overrides,
+    },
+  });
+}
+
 // Create a full pipeline of test data
 export async function createFullPipelineData() {
   const source = await createFeedbackSource();

--- a/packages/api/tests/integration/linear.routes.test.ts
+++ b/packages/api/tests/integration/linear.routes.test.ts
@@ -1,0 +1,314 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import { createApp } from '../../src/index';
+import { prisma } from '../setup';
+import { createTheme, createProposal, createLinearIssue } from '../helpers/factories';
+
+// Mock global fetch for Linear GraphQL API calls
+function mockFetch(response: unknown, status = 200) {
+  return vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(response),
+    text: () => Promise.resolve(JSON.stringify(response)),
+  } as Response);
+}
+
+async function seedLinearConfig() {
+  const settings = {
+    linear_api_key: 'lin_api_test_key_123',
+    linear_team_id: 'team-001',
+    linear_project_id: 'project-001',
+    linear_done_states: 'Done,Cancelled',
+    linear_default_label_id: 'label-001',
+    linear_cycle_id: 'cycle-001',
+  };
+  for (const [key, value] of Object.entries(settings)) {
+    await prisma.setting.upsert({
+      where: { key },
+      update: { value },
+      create: { key, value },
+    });
+  }
+}
+
+const app = createApp();
+
+describe('Linear Routes', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ─── PUT /api/linear/config ────────────────────────────
+
+  describe('PUT /api/linear/config', () => {
+    it('saves valid Linear config', async () => {
+      const res = await request(app)
+        .put('/api/linear/config')
+        .send({
+          linear_api_key: 'lin_api_my_key',
+          linear_team_id: 'team-123',
+        })
+        .expect(200);
+
+      expect(res.body.data.saved).toBe(true);
+
+      const key = await prisma.setting.findUnique({ where: { key: 'linear_api_key' } });
+      expect(key!.value).toBe('lin_api_my_key');
+    });
+
+    it('accepts partial config', async () => {
+      const res = await request(app)
+        .put('/api/linear/config')
+        .send({ linear_team_id: 'new-team' })
+        .expect(200);
+
+      expect(res.body.data.saved).toBe(true);
+    });
+
+    it('rejects empty API key', async () => {
+      await request(app).put('/api/linear/config').send({ linear_api_key: '' }).expect(400);
+    });
+  });
+
+  // ─── POST /api/linear/test ─────────────────────────────
+
+  describe('POST /api/linear/test', () => {
+    it('returns success when connection works', async () => {
+      await seedLinearConfig();
+      mockFetch({
+        data: { viewer: { id: 'u1', name: 'Test User', email: 'test@example.com' } },
+      });
+
+      const res = await request(app).post('/api/linear/test').expect(200);
+
+      expect(res.body.data.success).toBe(true);
+      expect(res.body.data.message).toContain('Test User');
+    });
+
+    it('returns failure when not configured', async () => {
+      const res = await request(app).post('/api/linear/test').expect(200);
+
+      expect(res.body.data.success).toBe(false);
+      expect(res.body.data.message).toContain('not configured');
+    });
+  });
+
+  // ─── GET /api/linear/teams ─────────────────────────────
+
+  describe('GET /api/linear/teams', () => {
+    it('returns team list', async () => {
+      await seedLinearConfig();
+      mockFetch({
+        data: {
+          teams: { nodes: [{ id: 't1', name: 'Engineering', key: 'ENG' }] },
+        },
+      });
+
+      const res = await request(app).get('/api/linear/teams').expect(200);
+      expect(res.body.data).toHaveLength(1);
+      expect(res.body.data[0].name).toBe('Engineering');
+    });
+  });
+
+  // ─── POST /api/linear/export/:proposalId ───────────────
+
+  describe('POST /api/linear/export/:proposalId', () => {
+    it('exports a proposal as a Linear issue', async () => {
+      await seedLinearConfig();
+      const theme = await createTheme();
+      const proposal = await createProposal(theme.id, { status: 'approved' });
+
+      mockFetch({
+        data: {
+          issueCreate: {
+            success: true,
+            issue: {
+              id: 'lin-issue-001',
+              identifier: 'ENG-42',
+              url: 'https://linear.app/team/issue/ENG-42',
+              title: proposal.title,
+              state: { name: 'Backlog' },
+              priority: 3,
+            },
+          },
+        },
+      });
+
+      const res = await request(app).post(`/api/linear/export/${proposal.id}`).expect(201);
+
+      expect(res.body.data.identifier).toBe('ENG-42');
+
+      // Verify DB record
+      const dbRecord = await prisma.linearIssue.findUnique({
+        where: { proposalId: proposal.id },
+      });
+      expect(dbRecord).not.toBeNull();
+      expect(dbRecord!.identifier).toBe('ENG-42');
+    });
+
+    it('returns 400 when already exported', async () => {
+      await seedLinearConfig();
+      const theme = await createTheme();
+      const proposal = await createProposal(theme.id, { status: 'approved' });
+      await createLinearIssue(proposal.id);
+
+      await request(app).post(`/api/linear/export/${proposal.id}`).expect(400);
+    });
+
+    it('returns 404 for nonexistent proposal', async () => {
+      await seedLinearConfig();
+
+      const res = await request(app).post('/api/linear/export/nonexistent-id');
+
+      // May be 404 or 400 depending on service implementation
+      expect([400, 404]).toContain(res.status);
+    });
+  });
+
+  // ─── POST /api/linear/sync/:proposalId ─────────────────
+
+  describe('POST /api/linear/sync/:proposalId', () => {
+    it('syncs status from Linear', async () => {
+      await seedLinearConfig();
+      const theme = await createTheme();
+      const proposal = await createProposal(theme.id, { status: 'approved' });
+      await createLinearIssue(proposal.id);
+
+      mockFetch({
+        data: {
+          issue: {
+            state: { name: 'In Progress' },
+            priority: 2,
+          },
+        },
+      });
+
+      const res = await request(app).post(`/api/linear/sync/${proposal.id}`).expect(200);
+
+      expect(res.body.data.status).toBe('In Progress');
+    });
+  });
+
+  // ─── GET /api/linear/issues ────────────────────────────
+
+  describe('GET /api/linear/issues', () => {
+    it('returns all exported issues', async () => {
+      const theme = await createTheme();
+      const p1 = await createProposal(theme.id);
+      const p2 = await createProposal(theme.id);
+      await createLinearIssue(p1.id, { identifier: 'ENG-1', linearId: 'lin-1' });
+      await createLinearIssue(p2.id, { identifier: 'ENG-2', linearId: 'lin-2' });
+
+      const res = await request(app).get('/api/linear/issues').expect(200);
+      expect(res.body.data).toHaveLength(2);
+    });
+
+    it('returns empty array when no issues', async () => {
+      const res = await request(app).get('/api/linear/issues').expect(200);
+      expect(res.body.data).toEqual([]);
+    });
+  });
+
+  // ─── GET /api/linear/issues/:proposalId ────────────────
+
+  describe('GET /api/linear/issues/:proposalId', () => {
+    it('returns linked issue for proposal', async () => {
+      const theme = await createTheme();
+      const proposal = await createProposal(theme.id);
+      await createLinearIssue(proposal.id, { identifier: 'ENG-99' });
+
+      const res = await request(app).get(`/api/linear/issues/${proposal.id}`).expect(200);
+
+      expect(res.body.data.identifier).toBe('ENG-99');
+    });
+
+    it('returns 404 when no linked issue', async () => {
+      const theme = await createTheme();
+      const proposal = await createProposal(theme.id);
+
+      await request(app).get(`/api/linear/issues/${proposal.id}`).expect(404);
+    });
+  });
+
+  // ─── DELETE /api/linear/issues/:proposalId ─────────────
+
+  describe('DELETE /api/linear/issues/:proposalId', () => {
+    it('unlinks a linear issue', async () => {
+      const theme = await createTheme();
+      const proposal = await createProposal(theme.id);
+      await createLinearIssue(proposal.id);
+
+      await request(app).delete(`/api/linear/issues/${proposal.id}`).expect(200);
+
+      const record = await prisma.linearIssue.findUnique({
+        where: { proposalId: proposal.id },
+      });
+      expect(record).toBeNull();
+    });
+  });
+
+  // ─── GET /api/linear/dashboard ─────────────────────────
+
+  describe('GET /api/linear/dashboard', () => {
+    it('returns dashboard summary', async () => {
+      const theme = await createTheme();
+      const proposal = await createProposal(theme.id);
+      await createLinearIssue(proposal.id, {
+        status: 'In Progress',
+        priority: 2,
+      });
+
+      const res = await request(app).get('/api/linear/dashboard').expect(200);
+      expect(res.body.data.totalExported).toBe(1);
+      expect(Object.keys(res.body.data.byStatus)).toHaveLength(1);
+    });
+  });
+
+  // ─── POST /api/linear/webhook ──────────────────────────
+
+  describe('POST /api/linear/webhook', () => {
+    it('processes a valid webhook payload', async () => {
+      await seedLinearConfig();
+      const theme = await createTheme();
+      const proposal = await createProposal(theme.id, { status: 'approved' });
+      await createLinearIssue(proposal.id, {
+        linearId: 'lin-webhook-001',
+        status: 'Backlog',
+      });
+
+      mockFetch({
+        data: {
+          issue: { state: { name: 'Done' }, priority: 1 },
+        },
+      });
+
+      const res = await request(app)
+        .post('/api/linear/webhook')
+        .send({
+          type: 'Issue',
+          action: 'update',
+          data: {
+            id: 'lin-webhook-001',
+            state: { name: 'Done' },
+          },
+        })
+        .expect(200);
+
+      expect(res.body.data.received).toBe(true);
+    });
+
+    it('ignores non-Issue webhook events', async () => {
+      const res = await request(app)
+        .post('/api/linear/webhook')
+        .send({
+          type: 'Comment',
+          action: 'create',
+          data: { id: 'comment-1' },
+        })
+        .expect(200);
+
+      expect(res.body.data.received).toBe(true);
+    });
+  });
+});

--- a/packages/api/tests/setup.ts
+++ b/packages/api/tests/setup.ts
@@ -17,6 +17,7 @@ beforeEach(async () => {
   // Clean all tables in dependency order (child tables first)
   await prisma.$transaction([
     prisma.trelloCard.deleteMany(),
+    prisma.linearIssue.deleteMany(),
     prisma.jiraIssue.deleteMany(),
     prisma.proposalEvidence.deleteMany(),
     prisma.spec.deleteMany(),

--- a/packages/api/tests/unit/linear-schema.test.ts
+++ b/packages/api/tests/unit/linear-schema.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { linearConfigSchema, linearImportSchema } from '../../src/schemas/linear.schema';
+
+describe('Linear Schemas', () => {
+  describe('linearConfigSchema', () => {
+    it('accepts valid full config', () => {
+      const result = linearConfigSchema.safeParse({
+        linear_api_key: 'lin_api_abc123',
+        linear_team_id: 'team-001',
+        linear_project_id: 'project-001',
+        linear_done_states: 'Done,Cancelled',
+        linear_default_label_id: 'label-001',
+        linear_cycle_id: 'cycle-001',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts partial config (all fields optional)', () => {
+      const result = linearConfigSchema.safeParse({
+        linear_api_key: 'lin_api_abc123',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts empty object', () => {
+      const result = linearConfigSchema.safeParse({});
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects empty API key', () => {
+      const result = linearConfigSchema.safeParse({
+        linear_api_key: '',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects empty team ID', () => {
+      const result = linearConfigSchema.safeParse({
+        linear_team_id: '',
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('linearImportSchema', () => {
+    it('accepts valid import options', () => {
+      const result = linearImportSchema.safeParse({
+        projectId: 'project-001',
+        stateType: 'started',
+        maxResults: 50,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts empty object', () => {
+      const result = linearImportSchema.safeParse({});
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects invalid stateType', () => {
+      const result = linearImportSchema.safeParse({
+        stateType: 'invalid_state',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects maxResults > 100', () => {
+      const result = linearImportSchema.safeParse({
+        maxResults: 200,
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects maxResults < 1', () => {
+      const result = linearImportSchema.safeParse({
+        maxResults: 0,
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/packages/api/tests/unit/linear-service.test.ts
+++ b/packages/api/tests/unit/linear-service.test.ts
@@ -1,0 +1,314 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { prisma } from '../setup';
+import { createTheme, createProposal, createLinearIssue } from '../helpers/factories';
+import { linearService, LINEAR_SETTING_KEYS } from '../../src/services/linear.service';
+
+// Helper to seed Linear config settings in the database
+async function seedLinearConfig(overrides: Record<string, string> = {}) {
+  const defaults: Record<string, string> = {
+    [LINEAR_SETTING_KEYS.LINEAR_API_KEY]: 'lin_api_test_key_123',
+    [LINEAR_SETTING_KEYS.LINEAR_TEAM_ID]: 'team-001',
+    [LINEAR_SETTING_KEYS.LINEAR_PROJECT_ID]: 'project-001',
+    [LINEAR_SETTING_KEYS.LINEAR_DONE_STATES]: 'Done,Cancelled',
+    [LINEAR_SETTING_KEYS.LINEAR_DEFAULT_LABEL_ID]: 'label-001',
+    [LINEAR_SETTING_KEYS.LINEAR_CYCLE_ID]: 'cycle-001',
+    ...overrides,
+  };
+  for (const [key, value] of Object.entries(defaults)) {
+    await prisma.setting.upsert({
+      where: { key },
+      update: { value },
+      create: { key, value },
+    });
+  }
+}
+
+// Mock global fetch for Linear GraphQL API calls
+function mockFetch(response: unknown, status = 200) {
+  return vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(response),
+    text: () => Promise.resolve(JSON.stringify(response)),
+  } as Response);
+}
+
+describe('Linear Service', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ─── testConnection ─────────────────────────────────────
+
+  describe('testConnection', () => {
+    it('returns success when Linear API responds', async () => {
+      await seedLinearConfig();
+      mockFetch({
+        data: { viewer: { id: 'u1', name: 'Test User', email: 'test@example.com' } },
+      });
+
+      const result = await linearService.testConnection();
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('Test User');
+      expect(result.userName).toBe('Test User');
+    });
+
+    it('returns failure when Linear is not configured', async () => {
+      const result = await linearService.testConnection();
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('not configured');
+    });
+
+    it('returns failure when Linear API rejects credentials', async () => {
+      await seedLinearConfig();
+      mockFetch({ errors: [{ message: 'Authentication required' }] });
+
+      const result = await linearService.testConnection();
+      expect(result.success).toBe(false);
+    });
+  });
+
+  // ─── listTeams ──────────────────────────────────────────
+
+  describe('listTeams', () => {
+    it('returns mapped team list', async () => {
+      await seedLinearConfig();
+      mockFetch({
+        data: {
+          teams: {
+            nodes: [
+              { id: 't1', name: 'Engineering', key: 'ENG' },
+              { id: 't2', name: 'Product', key: 'PRD' },
+            ],
+          },
+        },
+      });
+
+      const teams = await linearService.listTeams();
+      expect(teams).toHaveLength(2);
+      expect(teams[0]).toEqual({ id: 't1', name: 'Engineering', key: 'ENG' });
+    });
+
+    it('throws when not configured', async () => {
+      await expect(linearService.listTeams()).rejects.toThrow();
+    });
+  });
+
+  // ─── listProjects ───────────────────────────────────────
+
+  describe('listProjects', () => {
+    it('returns project list', async () => {
+      await seedLinearConfig();
+      mockFetch({
+        data: {
+          team: {
+            projects: {
+              nodes: [
+                {
+                  id: 'p1',
+                  name: 'Project Alpha',
+                  url: 'https://linear.app/team/project/p1',
+                  state: 'started',
+                },
+              ],
+            },
+          },
+        },
+      });
+
+      const projects = await linearService.listProjects();
+      expect(projects).toHaveLength(1);
+      expect(projects[0].name).toBe('Project Alpha');
+    });
+
+    it('throws when no team configured', async () => {
+      await seedLinearConfig({ [LINEAR_SETTING_KEYS.LINEAR_TEAM_ID]: '' });
+      await expect(linearService.listProjects()).rejects.toThrow();
+    });
+  });
+
+  // ─── exportProposal ─────────────────────────────────────
+
+  describe('exportProposal', () => {
+    it('exports a proposal as a Linear issue', async () => {
+      await seedLinearConfig();
+      const theme = await createTheme();
+      const proposal = await createProposal(theme.id, { status: 'approved' });
+
+      mockFetch({
+        data: {
+          issueCreate: {
+            success: true,
+            issue: {
+              id: 'lin-issue-001',
+              identifier: 'ENG-42',
+              url: 'https://linear.app/team/issue/ENG-42',
+              title: proposal.title,
+              state: { name: 'Backlog' },
+              priority: 3,
+            },
+          },
+        },
+      });
+
+      const result = await linearService.exportProposal(proposal.id);
+      expect(result.identifier).toBe('ENG-42');
+      expect(result.linearUrl).toContain('ENG-42');
+
+      // Verify DB record created
+      const dbRecord = await prisma.linearIssue.findUnique({
+        where: { proposalId: proposal.id },
+      });
+      expect(dbRecord).not.toBeNull();
+      expect(dbRecord!.identifier).toBe('ENG-42');
+      expect(dbRecord!.linearId).toBe('lin-issue-001');
+    });
+
+    it('throws when proposal already exported', async () => {
+      await seedLinearConfig();
+      const theme = await createTheme();
+      const proposal = await createProposal(theme.id, { status: 'approved' });
+      await createLinearIssue(proposal.id);
+
+      await expect(linearService.exportProposal(proposal.id)).rejects.toThrow('already exported');
+    });
+
+    it('throws when proposal not found', async () => {
+      await seedLinearConfig();
+      await expect(linearService.exportProposal('nonexistent-id')).rejects.toThrow();
+    });
+  });
+
+  // ─── syncStatus ─────────────────────────────────────────
+
+  describe('syncStatus', () => {
+    it('syncs status from Linear API', async () => {
+      await seedLinearConfig();
+      const theme = await createTheme();
+      const proposal = await createProposal(theme.id, { status: 'approved' });
+      await createLinearIssue(proposal.id);
+
+      mockFetch({
+        data: {
+          issue: {
+            state: { name: 'In Progress' },
+            priority: 2,
+          },
+        },
+      });
+
+      const result = await linearService.syncStatus(proposal.id);
+      expect(result.status).toBe('In Progress');
+
+      const dbRecord = await prisma.linearIssue.findUnique({
+        where: { proposalId: proposal.id },
+      });
+      expect(dbRecord!.status).toBe('In Progress');
+    });
+
+    it('throws when no linked issue', async () => {
+      const theme = await createTheme();
+      const proposal = await createProposal(theme.id);
+
+      await expect(linearService.syncStatus(proposal.id)).rejects.toThrow();
+    });
+  });
+
+  // ─── getByProposal ─────────────────────────────────────
+
+  describe('getByProposal', () => {
+    it('returns linked linear issue', async () => {
+      const theme = await createTheme();
+      const proposal = await createProposal(theme.id);
+      await createLinearIssue(proposal.id, { identifier: 'ENG-99' });
+
+      const issue = await linearService.getByProposal(proposal.id);
+      expect(issue).not.toBeNull();
+      expect(issue!.identifier).toBe('ENG-99');
+    });
+
+    it('returns null when no linked issue', async () => {
+      const theme = await createTheme();
+      const proposal = await createProposal(theme.id);
+
+      const issue = await linearService.getByProposal(proposal.id);
+      expect(issue).toBeNull();
+    });
+  });
+
+  // ─── unlink ─────────────────────────────────────────────
+
+  describe('unlink', () => {
+    it('removes the linear issue link', async () => {
+      const theme = await createTheme();
+      const proposal = await createProposal(theme.id);
+      await createLinearIssue(proposal.id);
+
+      await linearService.unlink(proposal.id);
+
+      const issue = await prisma.linearIssue.findUnique({
+        where: { proposalId: proposal.id },
+      });
+      expect(issue).toBeNull();
+    });
+
+    it('throws when no linked issue', async () => {
+      const theme = await createTheme();
+      const proposal = await createProposal(theme.id);
+
+      await expect(linearService.unlink(proposal.id)).rejects.toThrow();
+    });
+  });
+
+  // ─── listExported ───────────────────────────────────────
+
+  describe('listExported', () => {
+    it('returns all exported issues with proposal data', async () => {
+      const theme = await createTheme();
+      const p1 = await createProposal(theme.id, { title: 'Proposal 1' });
+      const p2 = await createProposal(theme.id, { title: 'Proposal 2' });
+      await createLinearIssue(p1.id, { identifier: 'ENG-1', linearId: 'lin-1' });
+      await createLinearIssue(p2.id, { identifier: 'ENG-2', linearId: 'lin-2' });
+
+      const issues = await linearService.listExported();
+      expect(issues).toHaveLength(2);
+    });
+
+    it('returns empty array when no exported issues', async () => {
+      const issues = await linearService.listExported();
+      expect(issues).toEqual([]);
+    });
+  });
+
+  // ─── getDashboardSummary ────────────────────────────────
+
+  describe('getDashboardSummary', () => {
+    it('returns summary with counts', async () => {
+      const theme = await createTheme();
+      const p1 = await createProposal(theme.id);
+      const p2 = await createProposal(theme.id);
+      await createLinearIssue(p1.id, {
+        identifier: 'ENG-10',
+        linearId: 'lin-10',
+        status: 'In Progress',
+        priority: 2,
+      });
+      await createLinearIssue(p2.id, {
+        identifier: 'ENG-11',
+        linearId: 'lin-11',
+        status: 'Done',
+        priority: 1,
+      });
+
+      const summary = await linearService.getDashboardSummary();
+      expect(summary.totalExported).toBe(2);
+      expect(Object.keys(summary.byStatus)).toHaveLength(2);
+    });
+
+    it('returns empty summary when no issues', async () => {
+      const summary = await linearService.getDashboardSummary();
+      expect(summary.totalExported).toBe(0);
+      expect(Object.keys(summary.byStatus)).toEqual([]);
+    });
+  });
+});

--- a/packages/web/src/components/dashboard/ActivityFeed.tsx
+++ b/packages/web/src/components/dashboard/ActivityFeed.tsx
@@ -1,4 +1,4 @@
-import { Upload, Brain, Lightbulb, FileText, Blocks, Trello } from 'lucide-react';
+import { Upload, Brain, Lightbulb, FileText, Blocks, Trello, Workflow } from 'lucide-react';
 import { formatDate } from '@/lib/utils';
 import type { ActivityEntry } from '@/lib/api';
 
@@ -9,6 +9,7 @@ const TYPE_ICONS: Record<string, React.ReactNode> = {
   spec_generation: <FileText size={16} className="text-success" />,
   jira_export: <Blocks size={16} className="text-accent-blue" />,
   trello_export: <Trello size={16} className="text-accent-blue" />,
+  linear_export: <Workflow size={16} className="text-accent-purple" />,
 };
 
 export function ActivityFeed({ activities }: { activities: ActivityEntry[] }) {

--- a/packages/web/src/components/dashboard/LinearSyncWidget.tsx
+++ b/packages/web/src/components/dashboard/LinearSyncWidget.tsx
@@ -1,0 +1,175 @@
+import { ExternalLink, RefreshCw, Workflow } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { Button } from '@/components/ui/Button';
+import { useLinearDashboard, useLinearSyncAll } from '@/hooks/useLinear';
+
+const STATUS_COLORS: Record<string, string> = {
+  Backlog: 'bg-text-muted/20 text-text-muted',
+  Todo: 'bg-text-muted/20 text-text-muted',
+  'In Progress': 'bg-accent-blue/20 text-accent-blue',
+  'In Review': 'bg-accent-purple/20 text-accent-purple',
+  Done: 'bg-success/20 text-success',
+  Completed: 'bg-success/20 text-success',
+  Cancelled: 'bg-danger/20 text-danger',
+};
+
+const PRIORITY_COLORS: Record<string, string> = {
+  Urgent: 'bg-danger/20 text-danger',
+  High: 'bg-warning/20 text-warning',
+  Medium: 'bg-accent-blue/20 text-accent-blue',
+  Low: 'bg-text-muted/20 text-text-muted',
+  'No Priority': 'bg-bg-surface-2 text-text-secondary',
+};
+
+function getStatusColor(status: string): string {
+  return STATUS_COLORS[status] || 'bg-bg-surface-2 text-text-secondary';
+}
+
+function getPriorityColor(priority: string): string {
+  return PRIORITY_COLORS[priority] || 'bg-bg-surface-2 text-text-secondary';
+}
+
+const PRIORITY_LABELS: Record<number, string> = {
+  0: 'No Priority',
+  1: 'Urgent',
+  2: 'High',
+  3: 'Medium',
+  4: 'Low',
+};
+
+export function LinearSyncWidget() {
+  const { data, isLoading } = useLinearDashboard();
+  const syncAllMutation = useLinearSyncAll();
+  const navigate = useNavigate();
+
+  if (isLoading || !data) return null;
+
+  if (data.totalExported === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-6 text-center">
+        <Workflow size={28} className="text-text-muted mb-2" />
+        <p className="text-sm text-text-secondary mb-1">No proposals exported to Linear yet</p>
+        <p className="text-xs text-text-muted mb-3">
+          Export proposals or themes from their detail pages, or configure Linear in Settings.
+        </p>
+        <Button variant="secondary" size="sm" onClick={() => navigate('/settings')}>
+          Configure Linear
+        </Button>
+      </div>
+    );
+  }
+
+  const statusEntries = Object.entries(data.byStatus).sort((a, b) => b[1] - a[1]);
+  const priorityEntries = Object.entries(data.byPriority).sort((a, b) => b[1] - a[1]);
+
+  return (
+    <div className="space-y-4">
+      {/* Summary stats */}
+      <div className="flex items-center gap-4">
+        <div className="text-center">
+          <p className="text-2xl font-bold text-text-primary">{data.totalExported}</p>
+          <p className="text-[10px] text-text-muted uppercase tracking-wider">Issues</p>
+        </div>
+        <div className="text-center">
+          <p className="text-2xl font-bold text-accent-purple">{statusEntries.length}</p>
+          <p className="text-[10px] text-text-muted uppercase tracking-wider">States</p>
+        </div>
+        <div className="flex-1" />
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => syncAllMutation.mutate()}
+          loading={syncAllMutation.isPending}
+          title="Sync all statuses from Linear"
+        >
+          <RefreshCw size={14} />
+          Sync All
+        </Button>
+      </div>
+
+      {syncAllMutation.data && (
+        <p className="text-xs text-success">
+          Synced {syncAllMutation.data.synced} issues
+          {syncAllMutation.data.autoShipped > 0 &&
+            `, ${syncAllMutation.data.autoShipped} auto-shipped`}
+        </p>
+      )}
+
+      {/* Status breakdown bar */}
+      {statusEntries.length > 0 && (
+        <div>
+          <div className="flex rounded-full overflow-hidden h-2 mb-2">
+            {statusEntries.map(([status, count]) => (
+              <div
+                key={status}
+                className={getStatusColor(status).split(' ')[0]}
+                style={{ width: `${(count / data.totalExported) * 100}%` }}
+                title={`${status}: ${count}`}
+              />
+            ))}
+          </div>
+          <div className="flex flex-wrap gap-x-3 gap-y-1">
+            {statusEntries.map(([status, count]) => (
+              <div key={status} className="flex items-center gap-1.5">
+                <span
+                  className={`inline-block w-2 h-2 rounded-full ${getStatusColor(status).split(' ')[0]}`}
+                />
+                <span className="text-[10px] text-text-muted">
+                  {status} ({count})
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Priority breakdown */}
+      {priorityEntries.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {priorityEntries.map(([priority, count]) => (
+            <span
+              key={priority}
+              className={`text-[10px] px-2 py-0.5 rounded-full ${getPriorityColor(priority)}`}
+            >
+              {priority}: {count}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {/* Recent exports */}
+      {data.recentExports.length > 0 && (
+        <div className="space-y-1.5">
+          <p className="text-[10px] text-text-muted uppercase tracking-wider">Recent</p>
+          {data.recentExports.map((issue) => (
+            <div
+              key={issue.identifier}
+              className="flex items-center gap-2 px-2 py-1.5 rounded-lg hover:bg-bg-surface-2 transition-colors"
+            >
+              <a
+                href={issue.linearUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-xs font-mono text-accent-blue hover:underline flex items-center gap-1 shrink-0"
+              >
+                {issue.identifier}
+                <ExternalLink size={9} />
+              </a>
+              <span
+                className={`text-[10px] px-1.5 py-0.5 rounded-full whitespace-nowrap ${getStatusColor(issue.status)}`}
+              >
+                {issue.status}
+              </span>
+              <span
+                className={`text-[10px] px-1.5 py-0.5 rounded-full whitespace-nowrap ${getPriorityColor(PRIORITY_LABELS[issue.priority] || 'No Priority')}`}
+              >
+                P{issue.priority}
+              </span>
+              <p className="text-xs text-text-secondary truncate flex-1">{issue.issueTitle}</p>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/components/dashboard/QuickActions.tsx
+++ b/packages/web/src/components/dashboard/QuickActions.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from 'react-router-dom';
-import { Upload, Brain, Lightbulb, Blocks, Trello } from 'lucide-react';
+import { Upload, Brain, Lightbulb, Blocks, Trello, Workflow } from 'lucide-react';
 
 export function QuickActions() {
   const navigate = useNavigate();
@@ -33,6 +33,12 @@ export function QuickActions() {
       label: 'Trello Integration',
       description: 'Export, sync & import from Trello',
       icon: <Trello size={20} />,
+      onClick: () => navigate('/settings'),
+    },
+    {
+      label: 'Linear Integration',
+      description: 'Export, sync & import from Linear',
+      icon: <Workflow size={20} />,
       onClick: () => navigate('/settings'),
     },
   ];

--- a/packages/web/src/components/feedback/ImportModal.tsx
+++ b/packages/web/src/components/feedback/ImportModal.tsx
@@ -7,13 +7,14 @@ import { Button } from '@/components/ui/Button';
 import { useImportPreview, useImportCSV, useImportJSON } from '@/hooks/useImport';
 import { useJiraImportFeedback } from '@/hooks/useJira';
 import { useTrelloImportFeedback } from '@/hooks/useTrello';
+import { useLinearImportFeedback } from '@/hooks/useLinear';
 
 interface ImportModalProps {
   isOpen: boolean;
   onClose: () => void;
 }
 
-type ImportSource = 'file' | 'jira' | 'trello';
+type ImportSource = 'file' | 'jira' | 'trello' | 'linear';
 type Step = 'upload' | 'preview' | 'progress';
 
 export function ImportModal({ isOpen, onClose }: ImportModalProps) {
@@ -39,6 +40,7 @@ export function ImportModal({ isOpen, onClose }: ImportModalProps) {
   const jsonMutation = useImportJSON();
   const jiraImportMutation = useJiraImportFeedback();
   const trelloImportMutation = useTrelloImportFeedback();
+  const linearImportMutation = useLinearImportFeedback();
 
   const handleFile = useCallback(
     async (f: File) => {
@@ -107,11 +109,19 @@ export function ImportModal({ isOpen, onClose }: ImportModalProps) {
 
   const handleTrelloImport = useCallback(async () => {
     try {
-      await trelloImportMutation.mutateAsync();
+      await trelloImportMutation.mutateAsync({});
     } catch {
       setError('Trello import failed. Check your Trello configuration in Settings.');
     }
   }, [trelloImportMutation]);
+
+  const handleLinearImport = useCallback(async () => {
+    try {
+      await linearImportMutation.mutateAsync({});
+    } catch {
+      setError('Linear import failed. Check your Linear configuration in Settings.');
+    }
+  }, [linearImportMutation]);
 
   const handleClose = useCallback(() => {
     setImportSource('file');
@@ -137,11 +147,13 @@ export function ImportModal({ isOpen, onClose }: ImportModalProps) {
       ? 'Import from Jira'
       : importSource === 'trello'
         ? 'Import from Trello'
-        : step === 'upload'
-          ? 'Import Feedback'
-          : step === 'preview'
-            ? 'Import Feedback — Map Columns'
-            : 'Import Feedback — Importing...';
+        : importSource === 'linear'
+          ? 'Import from Linear'
+          : step === 'upload'
+            ? 'Import Feedback'
+            : step === 'preview'
+              ? 'Import Feedback — Map Columns'
+              : 'Import Feedback — Importing...';
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
@@ -196,6 +208,19 @@ export function ImportModal({ isOpen, onClose }: ImportModalProps) {
           >
             From Trello
           </button>
+          <button
+            onClick={() => {
+              setImportSource('linear');
+              setError('');
+            }}
+            className={`flex-1 px-4 py-2.5 text-sm font-medium transition-colors ${
+              importSource === 'linear'
+                ? 'text-accent-blue border-b-2 border-accent-blue'
+                : 'text-text-muted hover:text-text-secondary'
+            }`}
+          >
+            From Linear
+          </button>
         </div>
 
         {/* Body */}
@@ -248,6 +273,24 @@ export function ImportModal({ isOpen, onClose }: ImportModalProps) {
                   <CheckCircle2 size={14} />
                   Imported {trelloImportMutation.data.imported} items (
                   {trelloImportMutation.data.skipped} duplicates skipped)
+                </p>
+              )}
+              {error && <p className="text-sm text-danger">{error}</p>}
+            </div>
+          ) : importSource === 'linear' ? (
+            <div className="space-y-4">
+              <p className="text-sm text-text-secondary">
+                Import issues from your configured Linear team as feedback items for AI analysis.
+              </p>
+              <Button onClick={handleLinearImport} loading={linearImportMutation.isPending}>
+                <Download size={14} />
+                Import from Linear
+              </Button>
+              {linearImportMutation.data && (
+                <p className="text-sm text-success flex items-center gap-1.5">
+                  <CheckCircle2 size={14} />
+                  Imported {linearImportMutation.data.imported} items (
+                  {linearImportMutation.data.skipped} duplicates skipped)
                 </p>
               )}
               {error && <p className="text-sm text-danger">{error}</p>}

--- a/packages/web/src/components/proposals/ProposalDetail.tsx
+++ b/packages/web/src/components/proposals/ProposalDetail.tsx
@@ -30,6 +30,13 @@ import {
   useTrelloUnlink,
   useTrelloAttachSpec,
 } from '@/hooks/useTrello';
+import {
+  useLinearExport,
+  useLinearIssueByProposal,
+  useLinearSyncStatus,
+  useLinearUnlink,
+  useLinearAttachSpec,
+} from '@/hooks/useLinear';
 import { getSentimentColor, getUrgencyColor } from '@/lib/utils';
 
 interface ProposalDetailProps {
@@ -74,6 +81,11 @@ export function ProposalDetail({ proposalId, onClose }: ProposalDetailProps) {
   const trelloUnlinkMutation = useTrelloUnlink();
   const trelloAttachSpecMutation = useTrelloAttachSpec();
   const { data: trelloCard } = useTrelloCardByProposal(proposalId);
+  const linearExportMutation = useLinearExport();
+  const linearSyncMutation = useLinearSyncStatus();
+  const linearUnlinkMutation = useLinearUnlink();
+  const linearAttachSpecMutation = useLinearAttachSpec();
+  const { data: linearIssue } = useLinearIssueByProposal(proposalId);
 
   if (isLoading) {
     return (
@@ -314,6 +326,92 @@ export function ProposalDetail({ proposalId, onClose }: ProposalDetailProps) {
             {trelloExportMutation.isError && (
               <p className="text-xs text-danger mt-1">
                 {(trelloExportMutation.error as Error)?.message || 'Failed to export'}
+              </p>
+            )}
+          </div>
+        )}
+
+        {/* Linear Integration */}
+        {(proposal.status === 'approved' || proposal.status === 'shipped') && (
+          <div>
+            {linearIssue ? (
+              <div className="bg-bg-surface-2 rounded-lg p-3">
+                <div className="flex items-center justify-between mb-1">
+                  <div className="flex items-center gap-2">
+                    <a
+                      href={linearIssue.linearUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-sm text-accent-blue hover:underline flex items-center gap-1"
+                    >
+                      {linearIssue.identifier}
+                      <ExternalLink size={10} />
+                    </a>
+                    <span className="text-[10px] px-1.5 py-0.5 rounded bg-bg-surface border border-border text-text-muted">
+                      {linearIssue.status}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-1">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => linearSyncMutation.mutate(proposal.id)}
+                      loading={linearSyncMutation.isPending}
+                      title="Sync status from Linear"
+                    >
+                      <RefreshCw size={12} />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => {
+                        if (
+                          confirm(
+                            'Unlink this Linear issue? The issue in Linear will not be deleted.',
+                          )
+                        ) {
+                          linearUnlinkMutation.mutate(proposal.id);
+                        }
+                      }}
+                      loading={linearUnlinkMutation.isPending}
+                      title="Unlink Linear issue"
+                    >
+                      <Unlink size={12} className="text-danger" />
+                    </Button>
+                  </div>
+                </div>
+                <p className="text-xs text-text-muted">Linked to Linear</p>
+                {existingSpec && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="mt-2"
+                    onClick={() => linearAttachSpecMutation.mutate(proposal.id)}
+                    loading={linearAttachSpecMutation.isPending}
+                    title="Attach PRD spec as a Linear comment"
+                  >
+                    <Paperclip size={12} />
+                    <span className="text-xs">
+                      {linearAttachSpecMutation.isSuccess
+                        ? 'Spec Attached!'
+                        : 'Attach Spec to Linear'}
+                    </span>
+                  </Button>
+                )}
+              </div>
+            ) : (
+              <Button
+                variant="secondary"
+                size="sm"
+                loading={linearExportMutation.isPending}
+                onClick={() => linearExportMutation.mutate(proposal.id)}
+              >
+                Export to Linear
+              </Button>
+            )}
+            {linearExportMutation.isError && (
+              <p className="text-xs text-danger mt-1">
+                {(linearExportMutation.error as Error)?.message || 'Failed to export'}
               </p>
             )}
           </div>

--- a/packages/web/src/components/settings/LinearConfigSection.tsx
+++ b/packages/web/src/components/settings/LinearConfigSection.tsx
@@ -1,0 +1,529 @@
+import { useState } from 'react';
+import {
+  CheckCircle2,
+  XCircle,
+  Eye,
+  EyeOff,
+  RefreshCw,
+  ExternalLink,
+  Download,
+  Copy,
+  Check,
+} from 'lucide-react';
+import { Button } from '@/components/ui/Button';
+import {
+  useLinearTestConnection,
+  useLinearSaveConfig,
+  useLinearTeams,
+  useLinearProjects,
+  useLinearLabels,
+  useLinearCycles,
+  useLinearIssues,
+  useLinearImportFeedback,
+  useLinearSyncAll,
+  useLinearRegisterWebhook,
+  useLinearUnregisterWebhook,
+} from '@/hooks/useLinear';
+
+interface LinearConfigSectionProps {
+  settings: Record<string, string>;
+  onUpdate: (key: string, value: string) => void;
+}
+
+const PRIORITY_LABELS: Record<number, string> = {
+  0: 'No Priority',
+  1: 'Urgent',
+  2: 'High',
+  3: 'Medium',
+  4: 'Low',
+};
+
+export function LinearConfigSection({ settings, onUpdate }: LinearConfigSectionProps) {
+  const [apiKey, setApiKey] = useState('');
+  const [showKey, setShowKey] = useState(false);
+  // Local overrides: null = not yet touched (fall through to settings)
+  const [localTeamId, setLocalTeamId] = useState<string | null>(null);
+  const [localProjectId, setLocalProjectId] = useState<string | null>(null);
+  const [localDefaultLabelId, setLocalDefaultLabelId] = useState<string | null>(null);
+  const [localCycleId, setLocalCycleId] = useState<string | null>(null);
+  const [localDoneStates, setLocalDoneStates] = useState<string | null>(null);
+
+  // Derived values: local override takes priority, then server setting
+  const teamId = localTeamId ?? settings['linear_team_id'] ?? '';
+  const projectId = localProjectId ?? settings['linear_project_id'] ?? '';
+  const defaultLabelId = localDefaultLabelId ?? settings['linear_default_label_id'] ?? '';
+  const cycleId = localCycleId ?? settings['linear_cycle_id'] ?? '';
+  const doneStates = localDoneStates ?? settings['linear_done_states'] ?? '';
+
+  const [copiedWebhook, setCopiedWebhook] = useState(false);
+
+  const testMutation = useLinearTestConnection();
+  const saveMutation = useLinearSaveConfig();
+  const teamsQuery = useLinearTeams();
+  const projectsQuery = useLinearProjects();
+  const labelsQuery = useLinearLabels();
+  const cyclesQuery = useLinearCycles();
+  const { data: linearIssues } = useLinearIssues();
+  const importMutation = useLinearImportFeedback();
+  const syncAllMutation = useLinearSyncAll();
+  const registerWebhookMutation = useLinearRegisterWebhook();
+  const unregisterWebhookMutation = useLinearUnregisterWebhook();
+
+  const hasKey = (settings['linear_api_key'] || '').length > 0;
+  const isConfigured = hasKey;
+  const webhookUrl = `${window.location.origin}/api/linear/webhook`;
+  const hasWebhookRegistered = (settings['linear_webhook_id'] || '').length > 0;
+
+  const handleSave = () => {
+    const config: Record<string, string> = {};
+    if (apiKey.trim()) config['linear_api_key'] = apiKey.trim();
+    if (teamId.trim()) config['linear_team_id'] = teamId.trim();
+    if (projectId.trim()) config['linear_project_id'] = projectId.trim();
+    if (defaultLabelId.trim()) config['linear_default_label_id'] = defaultLabelId.trim();
+    if (cycleId.trim()) config['linear_cycle_id'] = cycleId.trim();
+    config['linear_done_states'] = doneStates.trim();
+
+    saveMutation.mutate(config, {
+      onSuccess: () => {
+        setApiKey('');
+        Object.entries(config).forEach(([k, v]) => {
+          if (k !== 'linear_api_key') onUpdate(k, v);
+        });
+      },
+    });
+  };
+
+  const handleCopyWebhook = () => {
+    navigator.clipboard.writeText(webhookUrl);
+    setCopiedWebhook(true);
+    setTimeout(() => setCopiedWebhook(false), 2000);
+  };
+
+  return (
+    <div className="space-y-5">
+      {/* API Key */}
+      <div>
+        <label className="text-sm font-medium text-text-primary block mb-1.5">Linear API Key</label>
+        {hasKey && (
+          <p className="text-xs text-text-muted mb-2">
+            Key saved ({settings['linear_api_key']}). Enter a new one to replace it.
+          </p>
+        )}
+        <div className="relative">
+          <input
+            type={showKey ? 'text' : 'password'}
+            value={apiKey}
+            onChange={(e) => setApiKey(e.target.value)}
+            placeholder={hasKey ? 'Enter new API key to replace...' : 'lin_api_...'}
+            className="w-full bg-bg-surface-2 border border-border rounded-lg px-3 py-2 text-sm text-text-primary placeholder:text-text-muted pr-10 font-mono"
+          />
+          <button
+            type="button"
+            onClick={() => setShowKey(!showKey)}
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-text-muted hover:text-text-secondary"
+          >
+            {showKey ? <EyeOff size={14} /> : <Eye size={14} />}
+          </button>
+        </div>
+        <p className="text-[10px] text-text-muted mt-1">
+          Create a personal API key at{' '}
+          <a
+            href="https://linear.app/settings/api"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-accent-blue hover:underline"
+          >
+            Linear Settings → API
+            <ExternalLink size={10} className="inline ml-0.5" />
+          </a>
+        </p>
+      </div>
+
+      {/* Team Selection */}
+      <div className="pt-4 border-t border-border">
+        <div className="flex items-end gap-2 mb-4">
+          <div className="flex-1">
+            <label className="text-sm font-medium text-text-primary block mb-1.5">Team</label>
+            {teamsQuery.data && teamsQuery.data.length > 0 ? (
+              <select
+                value={teamId}
+                onChange={(e) => {
+                  setLocalTeamId(e.target.value);
+                  setLocalProjectId('');
+                  setLocalDefaultLabelId('');
+                  setLocalCycleId('');
+                }}
+                className="w-full bg-bg-surface-2 border border-border rounded-lg px-3 py-2 text-sm text-text-primary"
+              >
+                <option value="">Select a team...</option>
+                {teamsQuery.data.map((t) => (
+                  <option key={t.id} value={t.id}>
+                    {t.name} ({t.key})
+                  </option>
+                ))}
+              </select>
+            ) : (
+              <input
+                type="text"
+                value={teamId}
+                onChange={(e) => setLocalTeamId(e.target.value)}
+                placeholder="Team ID"
+                className="w-full bg-bg-surface-2 border border-border rounded-lg px-3 py-2 text-sm text-text-primary placeholder:text-text-muted font-mono"
+              />
+            )}
+          </div>
+          {isConfigured && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => teamsQuery.refetch()}
+              loading={teamsQuery.isFetching}
+            >
+              <RefreshCw size={14} />
+            </Button>
+          )}
+        </div>
+
+        {/* Project Selection */}
+        <div className="flex items-end gap-2 mb-4">
+          <div className="flex-1">
+            <label className="text-sm font-medium text-text-primary block mb-1.5">
+              Default Project (optional)
+            </label>
+            {projectsQuery.data && projectsQuery.data.length > 0 ? (
+              <select
+                value={projectId}
+                onChange={(e) => setLocalProjectId(e.target.value)}
+                className="w-full bg-bg-surface-2 border border-border rounded-lg px-3 py-2 text-sm text-text-primary"
+              >
+                <option value="">No default project</option>
+                {projectsQuery.data.map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {p.name}
+                  </option>
+                ))}
+              </select>
+            ) : (
+              <input
+                type="text"
+                value={projectId}
+                onChange={(e) => setLocalProjectId(e.target.value)}
+                placeholder="Project ID (optional)"
+                className="w-full bg-bg-surface-2 border border-border rounded-lg px-3 py-2 text-sm text-text-primary placeholder:text-text-muted font-mono"
+              />
+            )}
+          </div>
+          {isConfigured && teamId && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => projectsQuery.refetch()}
+              loading={projectsQuery.isFetching}
+            >
+              <RefreshCw size={14} />
+            </Button>
+          )}
+        </div>
+
+        {/* Default Label */}
+        <div className="flex items-end gap-2 mb-4">
+          <div className="flex-1">
+            <label className="text-sm font-medium text-text-primary block mb-1.5">
+              Default Label (optional)
+            </label>
+            {labelsQuery.data && labelsQuery.data.length > 0 ? (
+              <select
+                value={defaultLabelId}
+                onChange={(e) => setLocalDefaultLabelId(e.target.value)}
+                className="w-full bg-bg-surface-2 border border-border rounded-lg px-3 py-2 text-sm text-text-primary"
+              >
+                <option value="">No default label</option>
+                {labelsQuery.data.map((l) => (
+                  <option key={l.id} value={l.id}>
+                    {l.name}
+                  </option>
+                ))}
+              </select>
+            ) : (
+              <input
+                type="text"
+                value={defaultLabelId}
+                onChange={(e) => setLocalDefaultLabelId(e.target.value)}
+                placeholder="Label ID (optional)"
+                className="w-full bg-bg-surface-2 border border-border rounded-lg px-3 py-2 text-sm text-text-primary placeholder:text-text-muted font-mono"
+              />
+            )}
+          </div>
+          {isConfigured && teamId && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => labelsQuery.refetch()}
+              loading={labelsQuery.isFetching}
+            >
+              <RefreshCw size={14} />
+            </Button>
+          )}
+        </div>
+
+        {/* Cycle / Sprint */}
+        <div className="flex items-end gap-2">
+          <div className="flex-1">
+            <label className="text-sm font-medium text-text-primary block mb-1.5">
+              Active Cycle (optional)
+            </label>
+            {cyclesQuery.data && cyclesQuery.data.length > 0 ? (
+              <select
+                value={cycleId}
+                onChange={(e) => setLocalCycleId(e.target.value)}
+                className="w-full bg-bg-surface-2 border border-border rounded-lg px-3 py-2 text-sm text-text-primary"
+              >
+                <option value="">No cycle</option>
+                {cyclesQuery.data.map((c) => (
+                  <option key={c.id} value={c.id}>
+                    {c.name || `Cycle ${c.number}`}
+                  </option>
+                ))}
+              </select>
+            ) : (
+              <input
+                type="text"
+                value={cycleId}
+                onChange={(e) => setLocalCycleId(e.target.value)}
+                placeholder="Cycle ID (optional)"
+                className="w-full bg-bg-surface-2 border border-border rounded-lg px-3 py-2 text-sm text-text-primary placeholder:text-text-muted font-mono"
+              />
+            )}
+          </div>
+          {isConfigured && teamId && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => cyclesQuery.refetch()}
+              loading={cyclesQuery.isFetching}
+            >
+              <RefreshCw size={14} />
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {/* Done States */}
+      {isConfigured && teamId && (
+        <div className="pt-4 border-t border-border">
+          <label className="text-sm font-medium text-text-primary block mb-1.5">Done States</label>
+          <input
+            type="text"
+            value={doneStates}
+            onChange={(e) => setLocalDoneStates(e.target.value)}
+            placeholder="Done, Completed, Closed, Shipped, Released"
+            className="w-full bg-bg-surface-2 border border-border rounded-lg px-3 py-2 text-sm text-text-primary placeholder:text-text-muted"
+          />
+          <p className="text-[10px] text-text-muted mt-1">
+            Comma-separated state names that trigger auto-shipping proposals. Leave blank for
+            defaults. Linear&apos;s built-in &ldquo;completed&rdquo; state type is always
+            recognized.
+          </p>
+        </div>
+      )}
+
+      {/* Actions */}
+      <div className="flex items-center gap-2 pt-4 border-t border-border">
+        <Button size="sm" onClick={handleSave} loading={saveMutation.isPending}>
+          Save Configuration
+        </Button>
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={() => testMutation.mutate()}
+          loading={testMutation.isPending}
+          disabled={!isConfigured}
+        >
+          Test Connection
+        </Button>
+      </div>
+
+      {saveMutation.isSuccess && (
+        <p className="text-xs text-success flex items-center gap-1">
+          <CheckCircle2 size={12} /> Configuration saved.
+        </p>
+      )}
+
+      {testMutation.data && (
+        <div
+          className={`flex items-center gap-2 text-sm ${
+            testMutation.data.success ? 'text-success' : 'text-danger'
+          }`}
+        >
+          {testMutation.data.success ? <CheckCircle2 size={14} /> : <XCircle size={14} />}
+          {testMutation.data.message}
+        </div>
+      )}
+
+      {/* Exported Issues Overview */}
+      {linearIssues && linearIssues.length > 0 && (
+        <div className="pt-4 border-t border-border">
+          <h4 className="text-sm font-medium text-text-primary mb-2">
+            Exported Issues ({linearIssues.length})
+          </h4>
+          <div className="space-y-2 max-h-60 overflow-y-auto">
+            {linearIssues.map((issue) => (
+              <div
+                key={issue.id}
+                className="flex items-center justify-between bg-bg-surface-2 rounded-lg px-3 py-2"
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <a
+                      href={issue.linearUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-sm font-mono text-accent-blue hover:underline"
+                    >
+                      {issue.identifier}
+                    </a>
+                    <span className="text-[10px] px-1.5 py-0.5 rounded bg-bg-surface border border-border text-text-muted">
+                      {issue.status}
+                    </span>
+                    <span className="text-[10px] px-1.5 py-0.5 rounded bg-bg-surface border border-border text-text-muted">
+                      {PRIORITY_LABELS[issue.priority] || 'Unknown'}
+                    </span>
+                  </div>
+                  <p className="text-xs text-text-secondary truncate">
+                    {issue.proposal?.title || issue.issueTitle}
+                  </p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Import Feedback from Linear */}
+      {isConfigured && teamId && (
+        <div className="pt-4 border-t border-border">
+          <h4 className="text-sm font-medium text-text-primary mb-1">
+            Import Feedback from Linear
+          </h4>
+          <p className="text-[10px] text-text-muted mb-3">
+            Pull issues from your Linear team into ShipScope as feedback items for AI analysis.
+          </p>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => importMutation.mutate(projectId ? { projectId } : undefined)}
+            loading={importMutation.isPending}
+          >
+            <Download size={14} />
+            Import from Linear
+          </Button>
+          {importMutation.data && (
+            <p className="text-xs text-success mt-2 flex items-center gap-1">
+              <CheckCircle2 size={12} />
+              Imported {importMutation.data.imported} items ({importMutation.data.skipped}{' '}
+              duplicates skipped)
+            </p>
+          )}
+          {importMutation.isError && (
+            <p className="text-xs text-danger mt-2">
+              Import failed. Check your Linear credentials and team selection.
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Bulk Sync */}
+      {linearIssues && linearIssues.length > 0 && (
+        <div className="pt-4 border-t border-border">
+          <h4 className="text-sm font-medium text-text-primary mb-1">Status Sync</h4>
+          <p className="text-[10px] text-text-muted mb-3">
+            Sync all exported Linear issues back to ShipScope. Proposals are auto-marked as
+            &ldquo;shipped&rdquo; when their issue moves to a completed state.
+          </p>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => syncAllMutation.mutate()}
+            loading={syncAllMutation.isPending}
+          >
+            <RefreshCw size={14} />
+            Sync All Statuses
+          </Button>
+          {syncAllMutation.data && (
+            <p className="text-xs text-success mt-2 flex items-center gap-1">
+              <CheckCircle2 size={12} />
+              {syncAllMutation.data.synced} synced
+              {syncAllMutation.data.autoShipped > 0 &&
+                `, ${syncAllMutation.data.autoShipped} auto-shipped`}
+              {syncAllMutation.data.errors > 0 && `, ${syncAllMutation.data.errors} errors`}
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Webhook URL */}
+      {isConfigured && (
+        <div className="pt-4 border-t border-border">
+          <h4 className="text-sm font-medium text-text-primary mb-1">
+            Linear Webhook (Real-time Sync)
+          </h4>
+          <p className="text-[10px] text-text-muted mb-3">
+            {hasWebhookRegistered
+              ? 'Webhook is registered and active. Linear will send real-time issue updates.'
+              : 'Auto-register a webhook, or manually add this URL in Linear Settings → API → Webhooks.'}
+          </p>
+          <div className="flex items-center gap-2">
+            <code className="flex-1 text-xs bg-bg-surface-2 border border-border rounded-lg px-3 py-2 font-mono text-text-secondary truncate">
+              {webhookUrl}
+            </code>
+            <Button variant="ghost" size="sm" onClick={handleCopyWebhook}>
+              {copiedWebhook ? <Check size={14} className="text-success" /> : <Copy size={14} />}
+            </Button>
+          </div>
+          <div className="flex items-center gap-2 mt-3">
+            {hasWebhookRegistered ? (
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => unregisterWebhookMutation.mutate()}
+                disabled={unregisterWebhookMutation.isPending}
+              >
+                {unregisterWebhookMutation.isPending ? (
+                  <RefreshCw size={12} className="animate-spin mr-1.5" />
+                ) : null}
+                Unregister Webhook
+              </Button>
+            ) : (
+              <Button
+                variant="primary"
+                size="sm"
+                onClick={() => registerWebhookMutation.mutate(webhookUrl)}
+                disabled={registerWebhookMutation.isPending}
+              >
+                {registerWebhookMutation.isPending ? (
+                  <RefreshCw size={12} className="animate-spin mr-1.5" />
+                ) : null}
+                Auto-Register Webhook
+              </Button>
+            )}
+            {registerWebhookMutation.isSuccess && (
+              <span className="text-xs text-success flex items-center gap-1">
+                <CheckCircle2 size={12} /> Webhook registered
+              </span>
+            )}
+            {unregisterWebhookMutation.isSuccess && (
+              <span className="text-xs text-text-muted flex items-center gap-1">
+                <CheckCircle2 size={12} /> Webhook removed
+              </span>
+            )}
+            {(registerWebhookMutation.isError || unregisterWebhookMutation.isError) && (
+              <span className="text-xs text-error flex items-center gap-1">
+                <XCircle size={12} /> Failed
+              </span>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/components/themes/ThemeCard.tsx
+++ b/packages/web/src/components/themes/ThemeCard.tsx
@@ -36,6 +36,7 @@ export function ThemeCard({ theme, onClick }: ThemeCardProps) {
         <div className="flex items-center gap-1.5 flex-shrink-0">
           {theme.jiraEpicKey && <Badge variant="blue">Epic</Badge>}
           {theme.trelloBoardListId && <Badge variant="green">Trello</Badge>}
+          {theme.linearProjectId && <Badge variant="purple">Linear</Badge>}
           {theme.category && (
             <Badge variant={categoryVariants[theme.category] || 'gray'}>
               {categoryLabels[theme.category] || theme.category}

--- a/packages/web/src/components/themes/ThemeDetail.tsx
+++ b/packages/web/src/components/themes/ThemeDetail.tsx
@@ -6,6 +6,7 @@ import { getSentimentColor, getUrgencyColor } from '@/lib/utils';
 import { useThemeDetail } from '@/hooks/useThemes';
 import { useJiraExportTheme } from '@/hooks/useJira';
 import { useTrelloExportTheme } from '@/hooks/useTrello';
+import { useLinearExportTheme } from '@/hooks/useLinear';
 
 interface ThemeDetailProps {
   themeId: string;
@@ -36,6 +37,7 @@ export function ThemeDetail({ themeId, onClose }: ThemeDetailProps) {
   const { data: theme, isLoading } = useThemeDetail(themeId);
   const epicExportMutation = useJiraExportTheme();
   const trelloExportMutation = useTrelloExportTheme();
+  const linearExportMutation = useLinearExportTheme();
 
   if (isLoading) {
     return (
@@ -199,6 +201,53 @@ export function ThemeDetail({ themeId, onClose }: ThemeDetailProps) {
           {trelloExportMutation.isError && (
             <p className="text-xs text-danger mt-2">
               Export failed. Check your Trello configuration in Settings.
+            </p>
+          )}
+        </div>
+
+        {/* Linear Project Export */}
+        <div>
+          <h4 className="text-xs font-medium text-text-muted uppercase tracking-wider mb-2">
+            Linear Integration
+          </h4>
+          {theme.linearProjectId ? (
+            <div className="bg-bg-surface-2 rounded-lg p-3">
+              <div className="flex items-center gap-2">
+                <span className="text-xs text-text-muted">Linked as Project:</span>
+                {theme.linearProjectUrl ? (
+                  <a
+                    href={theme.linearProjectUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-sm text-accent-blue hover:underline flex items-center gap-1"
+                  >
+                    View Project
+                    <ExternalLink size={10} />
+                  </a>
+                ) : (
+                  <span className="text-sm text-text-secondary">Exported</span>
+                )}
+              </div>
+            </div>
+          ) : (
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => linearExportMutation.mutate(themeId)}
+              loading={linearExportMutation.isPending}
+            >
+              Export as Linear Project
+            </Button>
+          )}
+          {linearExportMutation.isSuccess && linearExportMutation.data && (
+            <p className="text-xs text-success mt-2">
+              Created project &ldquo;{linearExportMutation.data.projectName}&rdquo; with{' '}
+              {linearExportMutation.data.issuesCreated} issues
+            </p>
+          )}
+          {linearExportMutation.isError && (
+            <p className="text-xs text-danger mt-2">
+              Export failed. Check your Linear configuration in Settings.
             </p>
           )}
         </div>

--- a/packages/web/src/components/ui/Badge.tsx
+++ b/packages/web/src/components/ui/Badge.tsx
@@ -1,7 +1,7 @@
 import { cn } from '@/lib/utils';
 
 interface BadgeProps {
-  variant?: 'blue' | 'green' | 'yellow' | 'red' | 'gray';
+  variant?: 'blue' | 'green' | 'yellow' | 'red' | 'gray' | 'purple';
   children: React.ReactNode;
   className?: string;
 }
@@ -12,6 +12,7 @@ const variants = {
   yellow: 'bg-warning-dim text-warning',
   red: 'bg-danger-dim text-danger',
   gray: 'bg-bg-surface-2 text-text-secondary',
+  purple: 'bg-purple-500/10 text-purple-400',
 };
 
 export function Badge({ variant = 'gray', children, className }: BadgeProps) {

--- a/packages/web/src/hooks/useLinear.ts
+++ b/packages/web/src/hooks/useLinear.ts
@@ -1,0 +1,183 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { linearApi } from '@/lib/api';
+
+export function useLinearTestConnection() {
+  return useMutation({
+    mutationFn: () => linearApi.testConnection(),
+  });
+}
+
+export function useLinearSaveConfig() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (config: Record<string, string>) => linearApi.saveConfig(config),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['settings'] });
+    },
+  });
+}
+
+export function useLinearTeams() {
+  return useQuery({
+    queryKey: ['linear', 'teams'],
+    queryFn: () => linearApi.listTeams(),
+    enabled: false,
+    retry: false,
+  });
+}
+
+export function useLinearProjects() {
+  return useQuery({
+    queryKey: ['linear', 'projects'],
+    queryFn: () => linearApi.listProjects(),
+    enabled: false,
+    retry: false,
+  });
+}
+
+export function useLinearLabels() {
+  return useQuery({
+    queryKey: ['linear', 'labels'],
+    queryFn: () => linearApi.listLabels(),
+    enabled: false,
+    retry: false,
+  });
+}
+
+export function useLinearStates() {
+  return useQuery({
+    queryKey: ['linear', 'states'],
+    queryFn: () => linearApi.listStates(),
+    enabled: false,
+    retry: false,
+  });
+}
+
+export function useLinearCycles() {
+  return useQuery({
+    queryKey: ['linear', 'cycles'],
+    queryFn: () => linearApi.listCycles(),
+    enabled: false,
+    retry: false,
+  });
+}
+
+export function useLinearExport() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (proposalId: string) => linearApi.exportProposal(proposalId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['linear'] });
+    },
+  });
+}
+
+export function useLinearExportTheme() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (themeId: string) => linearApi.exportTheme(themeId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['linear'] });
+      queryClient.invalidateQueries({ queryKey: ['themes'] });
+    },
+  });
+}
+
+export function useLinearAttachSpec() {
+  return useMutation({
+    mutationFn: (proposalId: string) => linearApi.attachSpec(proposalId),
+  });
+}
+
+export function useLinearImportFeedback() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (options?: { projectId?: string; stateType?: string; maxResults?: number }) =>
+      linearApi.importFeedback(options),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['feedback'] });
+      queryClient.invalidateQueries({ queryKey: ['dashboard'] });
+    },
+  });
+}
+
+export function useLinearSyncStatus() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (proposalId: string) => linearApi.syncStatus(proposalId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['linear'] });
+    },
+  });
+}
+
+export function useLinearSyncAll() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => linearApi.syncAll(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['linear'] });
+      queryClient.invalidateQueries({ queryKey: ['proposals'] });
+    },
+  });
+}
+
+export function useLinearIssues() {
+  return useQuery({
+    queryKey: ['linear', 'issues'],
+    queryFn: () => linearApi.listIssues(),
+    staleTime: 60_000,
+  });
+}
+
+export function useLinearIssueByProposal(proposalId: string) {
+  return useQuery({
+    queryKey: ['linear', 'issue', proposalId],
+    queryFn: () => linearApi.getByProposal(proposalId),
+    staleTime: 60_000,
+  });
+}
+
+export function useLinearUnlink() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (proposalId: string) => linearApi.unlink(proposalId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['linear'] });
+    },
+  });
+}
+
+export function useLinearDashboard() {
+  return useQuery({
+    queryKey: ['linear', 'dashboard'],
+    queryFn: () => linearApi.dashboardSummary(),
+    staleTime: 60_000,
+  });
+}
+
+export function useLinearCreateAttachment() {
+  return useMutation({
+    mutationFn: (proposalId: string) => linearApi.createAttachment(proposalId),
+  });
+}
+
+export function useLinearRegisterWebhook() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (callbackUrl: string) => linearApi.registerWebhook(callbackUrl),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['settings'] });
+    },
+  });
+}
+
+export function useLinearUnregisterWebhook() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => linearApi.unregisterWebhook(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['settings'] });
+    },
+  });
+}

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -172,6 +172,8 @@ export interface ThemeItem {
   jiraEpicUrl: string | null;
   trelloBoardListId: string | null;
   trelloBoardListUrl: string | null;
+  linearProjectId: string | null;
+  linearProjectUrl: string | null;
   createdAt: string;
   updatedAt: string;
   feedbackItems: {
@@ -731,4 +733,199 @@ export const trelloApi = {
   // Board template
   createBoard: () =>
     api.post<{ data: TrelloCreateBoardResult }>('/trello/create-board').then((r) => r.data.data),
+};
+
+// ============================================
+// Linear Integration API
+// ============================================
+
+export interface LinearTestResult {
+  success: boolean;
+  message: string;
+  userName?: string;
+}
+
+export interface LinearTeam {
+  id: string;
+  name: string;
+  key: string;
+}
+
+export interface LinearProject {
+  id: string;
+  name: string;
+  url: string;
+  state: string;
+}
+
+export interface LinearLabel {
+  id: string;
+  name: string;
+  color: string;
+}
+
+export interface LinearState {
+  id: string;
+  name: string;
+  type: string;
+  color: string;
+}
+
+export interface LinearCycle {
+  id: string;
+  name: string | null;
+  number: number;
+  startsAt: string;
+  endsAt: string;
+}
+
+export interface LinearExportResult {
+  id: string;
+  identifier: string;
+  linearUrl: string;
+}
+
+export interface LinearThemeExportResult {
+  projectName: string;
+  projectUrl: string;
+  issuesCreated: number;
+  issuesSkipped: number;
+}
+
+export interface LinearImportResult {
+  imported: number;
+  skipped: number;
+  sourceId: string;
+}
+
+export interface LinearSyncAllResult {
+  synced: number;
+  autoShipped: number;
+  errors: number;
+}
+
+export interface LinearDashboardSummary {
+  totalExported: number;
+  byStatus: Record<string, number>;
+  byPriority: Record<string, number>;
+  recentExports: {
+    identifier: string;
+    issueTitle: string;
+    status: string;
+    priority: number;
+    linearUrl: string;
+    createdAt: string;
+  }[];
+}
+
+export interface LinearIssueItem {
+  id: string;
+  proposalId: string;
+  linearId: string;
+  identifier: string;
+  linearUrl: string;
+  teamId: string;
+  status: string;
+  priority: number;
+  issueTitle: string;
+  projectId: string | null;
+  projectName: string | null;
+  labelIds: string[];
+  cycleId: string | null;
+  estimate: number | null;
+  syncedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+  proposal: {
+    id: string;
+    title: string;
+    status: string;
+    riceScore: number | null;
+  };
+}
+
+export const linearApi = {
+  // Configuration
+  saveConfig: (config: Record<string, string>) =>
+    api.put<{ data: { saved: boolean } }>('/linear/config', config).then((r) => r.data.data),
+
+  testConnection: () =>
+    api.post<{ data: LinearTestResult }>('/linear/test').then((r) => r.data.data),
+
+  listTeams: () => api.get<{ data: LinearTeam[] }>('/linear/teams').then((r) => r.data.data),
+
+  listProjects: () =>
+    api.get<{ data: LinearProject[] }>('/linear/projects').then((r) => r.data.data),
+
+  listLabels: () => api.get<{ data: LinearLabel[] }>('/linear/labels').then((r) => r.data.data),
+
+  listStates: () => api.get<{ data: LinearState[] }>('/linear/states').then((r) => r.data.data),
+
+  listCycles: () => api.get<{ data: LinearCycle[] }>('/linear/cycles').then((r) => r.data.data),
+
+  // Export & Sync
+  exportProposal: (proposalId: string) =>
+    api.post<{ data: LinearExportResult }>(`/linear/export/${proposalId}`).then((r) => r.data.data),
+
+  syncStatus: (proposalId: string) =>
+    api
+      .post<{
+        data: { identifier: string; status: string; titleUpdated: boolean };
+      }>(`/linear/sync/${proposalId}`)
+      .then((r) => r.data.data),
+
+  listIssues: () => api.get<{ data: LinearIssueItem[] }>('/linear/issues').then((r) => r.data.data),
+
+  getByProposal: (proposalId: string) =>
+    api
+      .get<{ data: LinearIssueItem | null }>(`/linear/issues/${proposalId}`)
+      .then((r) => r.data.data),
+
+  unlink: (proposalId: string) => api.delete(`/linear/issues/${proposalId}`),
+
+  // Theme → Project bulk export
+  exportTheme: (themeId: string) =>
+    api
+      .post<{ data: LinearThemeExportResult }>(`/linear/export-theme/${themeId}`)
+      .then((r) => r.data.data),
+
+  // Spec attachment
+  attachSpec: (proposalId: string) =>
+    api
+      .post<{
+        data: { identifier: string; commented: boolean };
+      }>(`/linear/attach-spec/${proposalId}`)
+      .then((r) => r.data.data),
+
+  // Import from Linear
+  importFeedback: (options?: { projectId?: string; stateType?: string; maxResults?: number }) =>
+    api
+      .post<{ data: LinearImportResult }>('/linear/import-feedback', options || {})
+      .then((r) => r.data.data),
+
+  // Bulk sync
+  syncAll: () =>
+    api.post<{ data: LinearSyncAllResult }>('/linear/sync-all').then((r) => r.data.data),
+
+  // Dashboard
+  dashboardSummary: () =>
+    api.get<{ data: LinearDashboardSummary }>('/linear/dashboard').then((r) => r.data.data),
+
+  // Attachment
+  createAttachment: (proposalId: string, appBaseUrl?: string) =>
+    api
+      .post<{ data: { attachmentId: string } }>(`/linear/attach/${proposalId}`, {
+        appBaseUrl: appBaseUrl || window.location.origin,
+      })
+      .then((r) => r.data.data),
+
+  // Webhook registration
+  registerWebhook: (callbackUrl: string) =>
+    api
+      .post<{ data: { webhookId: string; enabled: boolean } }>('/linear/register-webhook', {
+        callbackUrl,
+      })
+      .then((r) => r.data.data),
+
+  unregisterWebhook: () => api.delete('/linear/register-webhook'),
 };

--- a/packages/web/src/pages/DashboardPage.tsx
+++ b/packages/web/src/pages/DashboardPage.tsx
@@ -12,6 +12,7 @@ import { DashboardEmptyState } from '@/components/dashboard/DashboardEmptyState'
 import { OnboardingSteps } from '@/components/dashboard/OnboardingSteps';
 import { JiraSyncWidget } from '@/components/dashboard/JiraSyncWidget';
 import { TrelloSyncWidget } from '@/components/dashboard/TrelloSyncWidget';
+import { LinearSyncWidget } from '@/components/dashboard/LinearSyncWidget';
 import {
   useDashboardStats,
   useActivityFeed,
@@ -145,6 +146,14 @@ export default function DashboardPage() {
                 Trello Integration
               </h3>
               <TrelloSyncWidget />
+            </div>
+
+            {/* Linear Integration Widget */}
+            <div className="bg-bg-surface border border-border rounded-xl p-5">
+              <h3 className="text-sm font-medium text-text-muted uppercase tracking-wider mb-4">
+                Linear Integration
+              </h3>
+              <LinearSyncWidget />
             </div>
 
             {/* Onboarding banner when some steps incomplete */}

--- a/packages/web/src/pages/SettingsPage.tsx
+++ b/packages/web/src/pages/SettingsPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Bot, Sliders, Database, Webhook, Info, Blocks, Trello } from 'lucide-react';
+import { Bot, Sliders, Database, Webhook, Info, Blocks, Trello, Workflow } from 'lucide-react';
 import { Topbar } from '@/components/layout/Topbar';
 import { PageContainer } from '@/components/layout/PageContainer';
 import { Skeleton } from '@/components/ui/Skeleton';
@@ -9,16 +9,18 @@ import { DataManagementSection } from '@/components/settings/DataManagementSecti
 import { WebhookSection } from '@/components/settings/WebhookSection';
 import { JiraConfigSection } from '@/components/settings/JiraConfigSection';
 import { TrelloConfigSection } from '@/components/settings/TrelloConfigSection';
+import { LinearConfigSection } from '@/components/settings/LinearConfigSection';
 import { AboutSection } from '@/components/settings/AboutSection';
 import { useSettings, useUpdateSettings } from '@/hooks/useSettings';
 
-type Section = 'ai' | 'synthesis' | 'jira' | 'trello' | 'data' | 'webhook' | 'about';
+type Section = 'ai' | 'synthesis' | 'jira' | 'trello' | 'linear' | 'data' | 'webhook' | 'about';
 
 const SECTIONS: { id: Section; label: string; icon: React.ReactNode }[] = [
   { id: 'ai', label: 'AI Configuration', icon: <Bot size={16} /> },
   { id: 'synthesis', label: 'Synthesis Settings', icon: <Sliders size={16} /> },
   { id: 'jira', label: 'Jira Integration', icon: <Blocks size={16} /> },
   { id: 'trello', label: 'Trello Integration', icon: <Trello size={16} /> },
+  { id: 'linear', label: 'Linear Integration', icon: <Workflow size={16} /> },
   { id: 'data', label: 'Data Management', icon: <Database size={16} /> },
   { id: 'webhook', label: 'Webhooks & API Keys', icon: <Webhook size={16} /> },
   { id: 'about', label: 'About', icon: <Info size={16} /> },
@@ -69,6 +71,7 @@ export default function SettingsPage() {
                 {activeSection === 'synthesis' && 'Tune the feedback clustering parameters.'}
                 {activeSection === 'jira' && 'Connect to Jira to export proposals as issues.'}
                 {activeSection === 'trello' && 'Connect to Trello to export proposals as cards.'}
+                {activeSection === 'linear' && 'Connect to Linear to export proposals as issues.'}
                 {activeSection === 'data' && 'Export or delete all application data.'}
                 {activeSection === 'webhook' && 'Manage webhook URL and API key authentication.'}
                 {activeSection === 'about' && 'Application version and links.'}
@@ -93,6 +96,9 @@ export default function SettingsPage() {
                   )}
                   {activeSection === 'trello' && (
                     <TrelloConfigSection settings={settings ?? {}} onUpdate={handleUpdate} />
+                  )}
+                  {activeSection === 'linear' && (
+                    <LinearConfigSection settings={settings ?? {}} onUpdate={handleUpdate} />
                   )}
                   {activeSection === 'data' && <DataManagementSection />}
                   {activeSection === 'webhook' && <WebhookSection />}


### PR DESCRIPTION
Closes #31 

## What

Adds a complete Linear integration to ShipScope — export proposals/themes, import feedback, bi-directional status sync, real-time webhooks with HMAC-SHA256 verification, rich issue attachments, and one-click webhook registration.

## Changes

### Backend (`packages/api`)

**New files:**
- **`src/services/linear.service.ts`** (1,379 lines) — 23 service methods:
  - `testConnection()` — Verify API key via GraphQL `viewer` query
  - `listTeams()`, `listProjects()`, `listLabels()`, `listStates()`, `listCycles()` — Config selectors
  - `exportProposal()` — Create Linear issue with priority, estimate, labels, markdown description
  - `exportThemeAsProject()` — Create Linear project + bulk-create child issues
  - `attachSpec()` — Post PRD as issue comment
  - `importFeedbackFromLinear()` — Import team issues as feedback items (deduped by `linear_id`)
  - `syncStatus()` — Pull single issue status with two-way title sync + auto-ship
  - `syncAllStatuses()` — Bulk sync all linked issues
  - `handleWebhook()` — Process incoming Issue webhooks for real-time sync
  - `createAttachment()` — Rich ShipScope attachment via Attachments API (RICE badge, metadata)
  - `registerWebhook()` / `unregisterWebhook()` — Programmatic webhook lifecycle
  - `getDashboardSummary()` — Stats by status and priority for dashboard widget
  - `verifyWebhookSignature()` — HMAC-SHA256 signature check with `timingSafeEqual`
  - Helper functions: `getOrCreateLabel()`, `buildLinearDescription()`, `riceToPriority()`, `effortToEstimate()`

- **`src/routes/linear.ts`** (447 lines) — 21 endpoints:

  | Method | Endpoint | Description |
  |--------|----------|-------------|
  | PUT | `/api/linear/config` | Save configuration |
  | POST | `/api/linear/test` | Test connection |
  | GET | `/api/linear/teams` | List teams |
  | GET | `/api/linear/projects` | List projects |
  | GET | `/api/linear/labels` | List labels |
  | GET | `/api/linear/states` | List workflow states |
  | GET | `/api/linear/cycles` | List active cycles |
  | POST | `/api/linear/export/:proposalId` | Export proposal → issue |
  | POST | `/api/linear/sync/:proposalId` | Sync single issue status |
  | GET | `/api/linear/issues` | List all exported issues |
  | GET | `/api/linear/issues/:proposalId` | Get linked issue |
  | DELETE | `/api/linear/issues/:proposalId` | Unlink issue |
  | POST | `/api/linear/export-theme/:themeId` | Export theme → project |
  | POST | `/api/linear/attach-spec/:proposalId` | Attach PRD as comment |
  | POST | `/api/linear/import-feedback` | Import issues as feedback |
  | POST | `/api/linear/sync-all` | Bulk sync all linked issues |
  | POST | `/api/linear/webhook` | Receive webhooks (signature-verified) |
  | POST | `/api/linear/attach/:proposalId` | Create rich attachment |
  | POST | `/api/linear/register-webhook` | Auto-register webhook |
  | DELETE | `/api/linear/register-webhook` | Unregister webhook |
  | GET | `/api/linear/dashboard` | Dashboard summary |

- **`src/schemas/linear.schema.ts`** — Zod schemas for config and import validation
- **`prisma/migrations/20260314100000_add_linear_integration/`** — `linear_issues` table + `Theme.linearProjectId/Url` columns

**Modified files:**
- `prisma/schema.prisma` — Added `LinearIssue` model with relations to `Proposal`, added fields to `Theme`
- `src/index.ts` — Registered `/api/linear` routes with demo guard
- `src/services/settings.service.ts` — Mask `linear_api_key` and `linear_webhook_secret` in responses
- `src/services/activity.service.ts` — Added `linear_export` activity type

### Frontend (`packages/web`)

**New files:**
- **`src/components/settings/LinearConfigSection.tsx`** (535 lines) — Full settings UI: API key, team/project/label/cycle selectors, done states, exported issues list, import button, sync-all, one-click webhook registration
- **`src/components/dashboard/LinearSyncWidget.tsx`** (175 lines) — Dashboard widget with export counts by status/priority and sync action
- **`src/hooks/useLinear.ts`** (183 lines) — 17 React Query hooks for all Linear operations
- **`src/lib/api.ts`** (+204 lines) — Linear types + `linearApi` client with 17 methods

**Modified files:**
- `src/pages/SettingsPage.tsx` — Added Linear integration tab
- `src/pages/DashboardPage.tsx` — Added LinearSyncWidget section
- `src/components/proposals/ProposalDetail.tsx` — Export-to-Linear button with sync, unlink, attach-spec actions
- `src/components/themes/ThemeDetail.tsx` — Export-as-Linear-project button
- `src/components/themes/ThemeCard.tsx` — Linear project badge
- `src/components/feedback/ImportModal.tsx` — Linear as import source
- `src/components/dashboard/QuickActions.tsx` — Linear integration shortcut
- `src/components/dashboard/ActivityFeed.tsx` — Linear export icon
- `src/components/ui/Badge.tsx` — Additional variants

### Documentation
- `README.md` — Added Linear to features list
- `docs/api-reference.md` — All 21 Linear endpoints documented
- `docs/architecture.md` — Linear added to system diagram and integration table
- `docs/self-hosting.md` — Linear setup and webhook configuration guide

### Tests (48 tests)
- **`tests/unit/linear-service.test.ts`** — 20 tests: service methods, error cases, mappings
- **`tests/unit/linear-schema.test.ts`** — 10 tests: config/import schema validation
- **`tests/integration/linear.routes.test.ts`** — 18 tests: all route endpoints
- `tests/helpers/factories.ts` — Added `createLinearIssue()` factory
- `tests/setup.ts` — Added `LinearIssue` cleanup

## Files Changed

| File | Lines | Type |
|------|-------|------|
| `services/linear.service.ts` | 1,379 | New |
| `routes/linear.ts` | 447 | New |
| `settings/LinearConfigSection.tsx` | 535 | New |
| `tests/integration/linear.routes.test.ts` | 327 | New |
| `tests/unit/linear-service.test.ts` | 311 | New |
| `api.ts` (Linear types + client) | +204 | Modified |
| `hooks/useLinear.ts` | 183 | New |
| `dashboard/LinearSyncWidget.tsx` | 175 | New |
| `docs/api-reference.md` | +242 | Modified |
| `schemas/linear.schema.ts` | 17 | New |
| 10 other modified files | +180 | Modified |
| **Total** | **~4,000 lines across 30 files** | |

## Security Highlights

- Webhook signature verification using `createHmac('sha256', secret)` + `timingSafeEqual` (constant-time comparison)
- Timestamp replay protection rejects payloads older than 60 seconds
- API key and webhook secret masked in settings responses
- Raw body parsing isolated to webhook route only

## Testing

```bash
cd packages/api
npx vitest run tests/unit/linear-service.test.ts tests/unit/linear-schema.test.ts tests/integration/linear.routes.test.ts